### PR TITLE
feat: add URL routing for games (/game/{id})

### DIFF
--- a/backend/static/index.html
+++ b/backend/static/index.html
@@ -4,8 +4,8 @@
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Clue Board Game</title>
-    <script type="module" crossorigin src="/assets/index-BkF3tVhc.js"></script>
-    <link rel="stylesheet" crossorigin href="/assets/index-BV44V0Ly.css">
+    <script type="module" crossorigin src="/assets/index-BuvxowQS.js"></script>
+    <link rel="stylesheet" crossorigin href="/assets/index-D3eS7wOb.css">
   </head>
   <body>
     <div id="app"></div>

--- a/frontend/src/components/Lobby.vue
+++ b/frontend/src/components/Lobby.vue
@@ -5,43 +5,145 @@
       <p class="subtitle">The Classic Mystery Game</p>
     </div>
 
-    <section class="panel">
-      <h2>Create a New Game</h2>
-      <input v-model="playerName" placeholder="Your name" />
-      <select v-model="playerType">
-        <option value="human">Human</option>
-        <option value="llm">LLM Agent</option>
-      </select>
-      <button :disabled="!playerName" @click="createGame">Create Game</button>
-    </section>
+    <!-- URL-based game join: show focused view for a specific game -->
+    <template v-if="urlGameId">
+      <section class="panel" v-if="urlGameLoading">
+        <p class="loading">Loading game {{ urlGameId }}...</p>
+      </section>
 
-    <section class="panel">
-      <h2>Join Existing Game</h2>
-      <input v-model="joinGameId" placeholder="Game ID (e.g. ABC123)" />
-      <input v-model="playerName" placeholder="Your name" />
-      <select v-model="playerType">
-        <option value="human">Human</option>
-        <option value="llm">LLM Agent</option>
-      </select>
-      <div class="join-buttons">
-        <button :disabled="!joinGameId || !playerName" @click="joinGame">Join Game</button>
-        <button class="observe-btn" :disabled="!joinGameId" @click="observeGame">Watch as Observer</button>
-      </div>
-    </section>
+      <section class="panel" v-else-if="urlGameError">
+        <p class="error">{{ urlGameError }}</p>
+        <button class="back-btn" @click="$emit('clear-url-game')">Back to Lobby</button>
+      </section>
 
-    <p v-if="error" class="error">{{ error }}</p>
+      <section class="panel" v-else>
+        <h2>Game {{ urlGameId }}</h2>
+        <p class="game-status-info" v-if="urlGameState">
+          {{ urlGameStatusText }}
+          <span v-if="urlGameState.players">
+            &mdash; {{ urlGameState.players.length }} player{{ urlGameState.players.length !== 1 ? 's' : '' }}
+          </span>
+        </p>
+
+        <div v-if="urlGameCanJoin" class="join-section">
+          <input v-model="playerName" placeholder="Your name" @keyup.enter="joinUrlGame" />
+          <select v-model="playerType">
+            <option value="human">Human</option>
+            <option value="llm">LLM Agent</option>
+          </select>
+          <div class="join-buttons">
+            <button :disabled="!playerName" @click="joinUrlGame">Join Game</button>
+            <button class="observe-btn" @click="observeUrlGame">Watch as Observer</button>
+          </div>
+        </div>
+
+        <div v-else class="join-section">
+          <button class="observe-btn full-width" @click="observeUrlGame">Watch as Observer</button>
+        </div>
+
+        <p v-if="error" class="error">{{ error }}</p>
+        <button class="back-btn" @click="$emit('clear-url-game')">Back to Lobby</button>
+      </section>
+    </template>
+
+    <!-- Normal lobby view -->
+    <template v-else>
+      <section class="panel">
+        <h2>Create a New Game</h2>
+        <input v-model="playerName" placeholder="Your name" />
+        <select v-model="playerType">
+          <option value="human">Human</option>
+          <option value="llm">LLM Agent</option>
+        </select>
+        <button :disabled="!playerName" @click="createGame">Create Game</button>
+      </section>
+
+      <section class="panel">
+        <h2>Join Existing Game</h2>
+        <input v-model="joinGameId" placeholder="Game ID (e.g. ABC123)" />
+        <input v-model="playerName" placeholder="Your name" />
+        <select v-model="playerType">
+          <option value="human">Human</option>
+          <option value="llm">LLM Agent</option>
+        </select>
+        <div class="join-buttons">
+          <button :disabled="!joinGameId || !playerName" @click="joinGame">Join Game</button>
+          <button class="observe-btn" :disabled="!joinGameId" @click="observeGame">Watch as Observer</button>
+        </div>
+      </section>
+
+      <p v-if="error" class="error">{{ error }}</p>
+    </template>
   </div>
 </template>
 
 <script setup>
-import { ref } from 'vue'
+import { ref, computed, watch } from 'vue'
 
-const emit = defineEmits(['game-joined', 'observe'])
+const props = defineProps({
+  urlGameId: { type: String, default: null },
+})
+
+const emit = defineEmits(['game-joined', 'observe', 'clear-url-game'])
 
 const playerName = ref('')
 const playerType = ref('human')
 const joinGameId = ref('')
 const error = ref('')
+
+// URL game state
+const urlGameState = ref(null)
+const urlGameLoading = ref(false)
+const urlGameError = ref('')
+
+const urlGameCanJoin = computed(() => {
+  return urlGameState.value?.status === 'waiting'
+})
+
+const urlGameStatusText = computed(() => {
+  const status = urlGameState.value?.status
+  if (status === 'waiting') return 'Waiting for players'
+  if (status === 'playing') return 'Game in progress'
+  if (status === 'finished') return 'Game finished'
+  return ''
+})
+
+watch(() => props.urlGameId, (gid) => {
+  if (gid) {
+    fetchUrlGame(gid)
+  } else {
+    urlGameState.value = null
+    urlGameLoading.value = false
+    urlGameError.value = ''
+  }
+}, { immediate: true })
+
+async function fetchUrlGame(gid) {
+  urlGameLoading.value = true
+  urlGameError.value = ''
+  urlGameState.value = null
+  try {
+    const res = await fetch(`/games/${gid}`)
+    if (!res.ok) {
+      urlGameError.value = 'Game not found'
+      return
+    }
+    urlGameState.value = await res.json()
+  } catch (e) {
+    urlGameError.value = 'Failed to load game: ' + e.message
+  } finally {
+    urlGameLoading.value = false
+  }
+}
+
+async function joinUrlGame() {
+  error.value = ''
+  await doJoin(props.urlGameId)
+}
+
+function observeUrlGame() {
+  emit('observe', { gameId: props.urlGameId })
+}
 
 async function createGame() {
   error.value = ''
@@ -134,6 +236,21 @@ h2 {
   color: #ddd;
 }
 
+.game-status-info {
+  color: #8899aa;
+  font-size: 0.9rem;
+  margin-bottom: 1rem;
+}
+
+.join-section {
+  margin-top: 0.5rem;
+}
+
+.loading {
+  color: #8899aa;
+  font-style: italic;
+}
+
 input, select {
   display: block;
   width: 100%;
@@ -191,6 +308,25 @@ button:disabled {
   border-color: #3498db;
   color: #3498db;
   background: rgba(52, 152, 219, 0.1);
+}
+
+.observe-btn.full-width {
+  width: 100%;
+}
+
+.back-btn {
+  background: transparent;
+  border: none;
+  color: #667;
+  font-weight: normal;
+  font-size: 0.85rem;
+  margin-top: 1rem;
+  cursor: pointer;
+  text-decoration: underline;
+}
+
+.back-btn:hover {
+  color: #aab;
 }
 
 .error {

--- a/frontend/src/components/WaitingRoom.vue
+++ b/frontend/src/components/WaitingRoom.vue
@@ -5,8 +5,8 @@
 
     <div class="game-id-box">
       <span>Game ID: <strong>{{ gameId }}</strong></span>
-      <button class="copy-btn" @click="copyId" :title="copied ? 'Copied!' : 'Copy to clipboard'">
-        {{ copied ? 'Copied!' : 'Copy' }}
+      <button class="copy-btn" @click="copyLink" :title="copied ? 'Copied!' : 'Copy invite link'">
+        {{ copied ? 'Copied!' : 'Copy Link' }}
       </button>
     </div>
 
@@ -33,6 +33,7 @@
     </button>
     <p v-if="players.length < 2" class="hint">Need at least 2 players to start.</p>
     <p v-if="error" class="error">{{ error }}</p>
+    <button class="leave-btn" @click="$emit('leave-game')">Leave Game</button>
   </div>
 </template>
 
@@ -62,7 +63,7 @@ const props = defineProps({
   playerId: String,
   players: Array,
 })
-const emit = defineEmits(['game-started'])
+const emit = defineEmits(['game-started', 'leave-game'])
 
 const error = ref('')
 const copied = ref(false)
@@ -76,8 +77,9 @@ function tokenStyle(player) {
   return { backgroundColor: colors.bg, color: colors.text }
 }
 
-function copyId() {
-  navigator.clipboard.writeText(props.gameId)
+function copyLink() {
+  const url = `${window.location.origin}/game/${props.gameId}`
+  navigator.clipboard.writeText(url)
   copied.value = true
   setTimeout(() => { copied.value = false }, 2000)
 }
@@ -253,5 +255,20 @@ li:last-child {
   color: #e74c3c;
   margin-top: 0.5rem;
   font-size: 0.9rem;
+}
+
+.leave-btn {
+  background: transparent;
+  border: none;
+  color: #667;
+  font-weight: normal;
+  font-size: 0.85rem;
+  margin-top: 1rem;
+  cursor: pointer;
+  text-decoration: underline;
+}
+
+.leave-btn:hover {
+  color: #aab;
 }
 </style>


### PR DESCRIPTION
Navigating to /game/ABC123 now fetches the game and lets you pick a name
to join (if still waiting) or watch as an observer (if in progress/finished).

- App.vue: parse URL on mount, pushState on join/observe, popstate handler
- Lobby.vue: URL-aware mode shows game status with join/observe options
- WaitingRoom.vue: "Copy Link" shares the full /game/{id} URL
- Backend: SPA catch-all route serves index.html for /game/{id} paths

https://claude.ai/code/session_01Cx8DoJvw3uKRNZoXSnnCF4