### PR TITLE
Fix game state buttons not showing on player's turn

### DIFF
--- a/frontend/src/App.vue
+++ b/frontend/src/App.vue
@@ -158,7 +158,11 @@ function handleMessage(msg) {
     case 'game_started':
       if (msg.your_cards) yourCards.value = msg.your_cards
       if (msg.available_actions) availableActions.value = msg.available_actions
-      if (gameState.value) {
+      if (msg.state) {
+        // Broadcast with full state object — use it directly
+        gameState.value = msg.state
+      } else if (gameState.value) {
+        // Individual per-player message with top-level fields
         gameState.value = { ...gameState.value, status: 'playing', whose_turn: msg.whose_turn }
       }
       break
@@ -312,6 +316,8 @@ async function sendAction(action) {
     body: JSON.stringify({ player_id: playerId.value, action })
   })
   if (res.ok) {
+    const result = await res.json()
+    if (result.available_actions) availableActions.value = result.available_actions
     // Refresh full state to stay in sync
     try {
       const stateRes = await fetch(`/games/${gameId.value}`)


### PR DESCRIPTION
The game_started broadcast message ({type: "game_started", state: {...}})
was being handled the same as the individual per-player message, causing
whose_turn to be overwritten with undefined. This made isMyTurn false for
all players, hiding all action buttons after game start.

Also fixes:
- end_turn broadcast now includes all reset fields (dice_rolled, last_roll,
  suggestions_this_turn, pending_show_card) so frontend state stays in sync
- Suggesting player now receives updated available_actions while waiting
  for another player to show a card
- Action HTTP response now includes available_actions for reliable sync

https://claude.ai/code/session_01Fty7wJUv4TK44XU77qjUT3