### PR TITLE
Fix Kubernetes and Docker builds to serve static assets from backend

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -1,11 +1,26 @@
+# ---- Stage 1: Build frontend assets ----
+FROM node:22-alpine AS frontend-build
+
+WORKDIR /app
+
+COPY frontend/package.json frontend/package-lock.json* ./
+RUN npm install
+
+COPY frontend/ .
+RUN npm run build -- --outDir /assets
+
+# ---- Stage 2: Python backend + static assets ----
 FROM python:3.12-slim
 
 WORKDIR /app
 
-COPY pyproject.toml .
+COPY backend/pyproject.toml .
 RUN pip install --no-cache-dir .
 
-COPY . .
+COPY backend/ .
+
+# Copy frontend build output into the static directory
+COPY --from=frontend-build /assets ./static
 
 EXPOSE 8000
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,7 +6,8 @@ services:
 
   backend:
     build:
-      context: ./backend
+      context: .
+      dockerfile: backend/Dockerfile
     command: uvicorn app.main:app --host 0.0.0.0 --port 8000 --reload
     environment:
       - REDIS_URL=redis://redis:6379

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -1,4 +1,4 @@
-# ---- build stage ----
+# ---- Build stage ----
 FROM node:22-alpine AS build
 
 WORKDIR /app
@@ -9,6 +9,12 @@ RUN npm install
 COPY . .
 RUN npm run build -- --outDir dist
 
-EXPOSE 5173
+# ---- Runtime stage: nginx serves the built assets ----
+FROM nginx:alpine
 
-CMD ["npm", "run", "preview", "--", "--host", "0.0.0.0", "--port", "5173"]
+COPY --from=build /app/dist /usr/share/nginx/html
+COPY nginx.conf /etc/nginx/conf.d/default.conf
+
+EXPOSE 80
+
+CMD ["nginx", "-g", "daemon off;"]

--- a/k8s/backend.yaml
+++ b/k8s/backend.yaml
@@ -16,7 +16,9 @@ spec:
     spec:
       containers:
         - name: backend
+          # Build from repo root: docker build -f backend/Dockerfile .
           # Replace with your registry image, e.g. ghcr.io/your-org/clue-backend:v1.0.0
+          # This image includes the frontend static assets (Vue SPA build).
           image: clue-backend:latest
           ports:
             - containerPort: 8000

--- a/k8s/frontend.yaml
+++ b/k8s/frontend.yaml
@@ -1,3 +1,7 @@
+# NOTE: This frontend deployment is NOT required when static assets are served
+# from the backend image (the default). The backend Dockerfile includes a
+# multi-stage build that bundles the Vue SPA into backend/static/.
+# Keep this manifest only if you want to run a standalone nginx frontend.
 apiVersion: apps/v1
 kind: Deployment
 metadata:

--- a/k8s/ingress.yaml
+++ b/k8s/ingress.yaml
@@ -13,24 +13,11 @@ spec:
   rules:
     - http:
         paths:
-          - path: /games
-            pathType: Prefix
-            backend:
-              service:
-                name: backend
-                port:
-                  number: 8000
-          - path: /ws
-            pathType: Prefix
-            backend:
-              service:
-                name: backend
-                port:
-                  number: 8000
+          # Backend serves API, WebSocket, and static assets (Vue SPA)
           - path: /
             pathType: Prefix
             backend:
               service:
-                name: frontend
+                name: backend
                 port:
-                  number: 80
+                  number: 8000


### PR DESCRIPTION
The backend already had code to serve Vue SPA static assets but the
build pipeline never included them in the backend image. This fixes
several issues:

- Backend Dockerfile: multi-stage build that builds the frontend in
  stage 1 (Node) and copies the output into backend/static/ in stage 2
  (Python). Build context is now the repo root.
- Frontend Dockerfile: proper multi-stage build using nginx for the
  runtime stage instead of npm run preview (fixes port 80 mismatch
  with K8s frontend.yaml and actually uses the existing nginx.conf).
- K8s ingress: routes all traffic to the backend since it now serves
  both API and static assets.
- docker-compose: updated build context for the new backend Dockerfile.

https://claude.ai/code/session_01NvvhM2r4yHjP1aP3V6aD9t