### PR TITLE
Add wait loop for human player card show actions

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -340,6 +340,10 @@ async def _run_agent_loop(game_id: str):
                 logger.info("Agent %s showing card in game %s", pid, game_id)
                 await _execute_action(game_id, pid, {"type": "show_card", "card": card})
 
+            elif pending:
+                # A non-agent (human) player must show a card — wait for them
+                await asyncio.sleep(0.5)
+
             elif state["whose_turn"] in agents:
                 # It's an agent's turn — pace actions for human observers
                 await asyncio.sleep(1.5)


### PR DESCRIPTION
## Summary
Added a polling mechanism to wait for human players to show cards during the agent loop, preventing the game from progressing until the required action is completed.

## Key Changes
- Added a new conditional branch in `_run_agent_loop()` to detect when a human player has a pending card show action
- Implements a 0.5-second sleep interval to poll for human player actions without blocking the event loop
- Ensures the game waits appropriately for human input before proceeding to agent turns

## Implementation Details
The new logic checks if there's a pending action (`elif pending:`) and yields control back to the event loop with a brief sleep, allowing human players time to respond while keeping the agent loop responsive. This maintains the existing pacing behavior where agent turns have a 1.5-second delay for observer visibility.

https://claude.ai/code/session_015SFZnD414LAG65qf82uSAt