### PR TITLE
Add Kubernetes deploy script and GitHub Actions deploy workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches: [main]
   pull_request:
+  workflow_call:
 
 permissions:
   contents: read
@@ -35,6 +36,6 @@ jobs:
         with:
           python-version: "3.12"
           cache: "pip"
-          cache-dependency-path: backend/requirements.txt
+          cache-dependency-path: backend/pyproject.toml
       - run: pip install .
       - run: pytest

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,127 @@
+name: Deploy
+
+on:
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  packages: write
+
+env:
+  REGISTRY: ghcr.io
+  BACKEND_IMAGE: ghcr.io/${{ github.repository }}-backend
+  FRONTEND_IMAGE: ghcr.io/${{ github.repository }}-frontend
+
+jobs:
+  test:
+    name: Test
+    uses: ./.github/workflows/ci.yml
+
+  build-backend:
+    name: Build Backend Image
+    needs: test
+    runs-on: ubuntu-latest
+    outputs:
+      image-tag: ${{ steps.meta.outputs.version }}
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ env.BACKEND_IMAGE }}
+          tags: |
+            type=sha,prefix=
+            type=raw,value=latest
+
+      - uses: docker/build-push-action@v6
+        with:
+          context: backend
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+
+  build-frontend:
+    name: Build Frontend Image
+    needs: test
+    runs-on: ubuntu-latest
+    outputs:
+      image-tag: ${{ steps.meta.outputs.version }}
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ env.FRONTEND_IMAGE }}
+          tags: |
+            type=sha,prefix=
+            type=raw,value=latest
+
+      - uses: docker/build-push-action@v6
+        with:
+          context: frontend
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+
+  deploy:
+    name: Deploy to Kubernetes
+    needs: [build-backend, build-frontend]
+    runs-on: ubuntu-latest
+    environment: production
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Configure kubectl
+        uses: azure/setup-kubectl@v4
+
+      - name: Set Kubernetes context
+        uses: azure/k8s-set-context@v4
+        with:
+          kubeconfig: ${{ secrets.KUBECONFIG }}
+
+      - name: Create namespace
+        run: kubectl apply -f k8s/namespace.yaml
+
+      - name: Deploy Redis
+        run: kubectl apply -n clue -f k8s/redis.yaml
+
+      - name: Deploy backend
+        run: |
+          kubectl apply -n clue -f k8s/backend.yaml
+          kubectl set image -n clue deployment/backend \
+            backend=${{ env.BACKEND_IMAGE }}:${{ needs.build-backend.outputs.image-tag }}
+
+      - name: Deploy frontend
+        run: |
+          kubectl apply -n clue -f k8s/frontend.yaml
+          kubectl set image -n clue deployment/frontend \
+            frontend=${{ env.FRONTEND_IMAGE }}:${{ needs.build-frontend.outputs.image-tag }}
+
+      - name: Apply ingress
+        run: kubectl apply -n clue -f k8s/ingress.yaml
+
+      - name: Wait for rollout
+        run: |
+          kubectl rollout status -n clue deployment/redis --timeout=120s
+          kubectl rollout status -n clue deployment/backend --timeout=120s
+          kubectl rollout status -n clue deployment/frontend --timeout=120s
+
+      - name: Show deployment status
+        if: always()
+        run: kubectl get pods -n clue

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -9,4 +9,4 @@ COPY . .
 
 EXPOSE 8000
 
-CMD ["python", "main.py", "--host", "0.0.0.0", "--port", "8000"]
+CMD ["uvicorn", "app.main:app", "--host", "0.0.0.0", "--port", "8000"]

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -9,6 +9,12 @@ RUN npm install
 COPY . .
 RUN npm run build -- --outDir dist
 
-EXPOSE 5173
+# ---- production stage ----
+FROM nginx:alpine
 
-CMD ["npm", "run", "preview", "--", "--host", "0.0.0.0", "--port", "5173"]
+COPY nginx.conf /etc/nginx/conf.d/default.conf
+COPY --from=build /app/dist /usr/share/nginx/html
+
+EXPOSE 80
+
+CMD ["nginx", "-g", "daemon off;"]

--- a/k8s/namespace.yaml
+++ b/k8s/namespace.yaml
@@ -1,0 +1,4 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: clue

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -1,0 +1,104 @@
+#!/usr/bin/env bash
+#
+# deploy.sh — Build, push, and deploy the Clue app to Kubernetes.
+#
+# Usage:
+#   ./scripts/deploy.sh                          # defaults: registry=ghcr.io/<git-owner>/clue, tag=latest
+#   ./scripts/deploy.sh -r ghcr.io/myorg/clue -t v1.2.3
+#   ./scripts/deploy.sh -t $(git rev-parse --short HEAD)
+#
+# Prerequisites:
+#   - docker (logged in to your registry)
+#   - kubectl (configured for the target cluster)
+#
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ROOT_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+
+# ── Defaults ──────────────────────────────────────────────────────────────────
+# Try to detect the registry from the git remote
+DEFAULT_OWNER=$(git -C "$ROOT_DIR" remote get-url origin 2>/dev/null \
+  | sed -n 's#.*github\.com[:/]\([^/]*\)/.*#\1#p' \
+  | tr '[:upper:]' '[:lower:]')
+DEFAULT_REGISTRY="ghcr.io/${DEFAULT_OWNER:-clue}/clue"
+
+REGISTRY="${REGISTRY:-$DEFAULT_REGISTRY}"
+TAG="${TAG:-latest}"
+NAMESPACE="clue"
+SKIP_BUILD=false
+
+# ── Parse flags ───────────────────────────────────────────────────────────────
+usage() {
+  echo "Usage: $0 [-r REGISTRY] [-t TAG] [-n NAMESPACE] [--skip-build]"
+  echo ""
+  echo "  -r REGISTRY   Container registry prefix (default: $DEFAULT_REGISTRY)"
+  echo "  -t TAG         Image tag (default: latest)"
+  echo "  -n NAMESPACE   Kubernetes namespace (default: clue)"
+  echo "  --skip-build   Skip Docker build/push, only apply manifests"
+  exit 1
+}
+
+while [[ $# -gt 0 ]]; do
+  case $1 in
+    -r) REGISTRY="$2"; shift 2 ;;
+    -t) TAG="$2"; shift 2 ;;
+    -n) NAMESPACE="$2"; shift 2 ;;
+    --skip-build) SKIP_BUILD=true; shift ;;
+    -h|--help) usage ;;
+    *) echo "Unknown option: $1"; usage ;;
+  esac
+done
+
+BACKEND_IMAGE="$REGISTRY-backend:$TAG"
+FRONTEND_IMAGE="$REGISTRY-frontend:$TAG"
+
+echo "==> Configuration"
+echo "    Registry:  $REGISTRY"
+echo "    Tag:       $TAG"
+echo "    Namespace: $NAMESPACE"
+echo "    Backend:   $BACKEND_IMAGE"
+echo "    Frontend:  $FRONTEND_IMAGE"
+echo ""
+
+# ── Build & push ──────────────────────────────────────────────────────────────
+if [ "$SKIP_BUILD" = false ]; then
+  echo "==> Building backend image..."
+  docker build -t "$BACKEND_IMAGE" "$ROOT_DIR/backend"
+
+  echo "==> Building frontend image..."
+  docker build -t "$FRONTEND_IMAGE" "$ROOT_DIR/frontend"
+
+  echo "==> Pushing images..."
+  docker push "$BACKEND_IMAGE"
+  docker push "$FRONTEND_IMAGE"
+else
+  echo "==> Skipping build (--skip-build)"
+fi
+
+# ── Deploy to Kubernetes ──────────────────────────────────────────────────────
+echo "==> Creating namespace '$NAMESPACE' (if needed)..."
+kubectl apply -f "$ROOT_DIR/k8s/namespace.yaml"
+
+echo "==> Deploying Redis..."
+kubectl apply -n "$NAMESPACE" -f "$ROOT_DIR/k8s/redis.yaml"
+
+echo "==> Deploying backend..."
+kubectl apply -n "$NAMESPACE" -f "$ROOT_DIR/k8s/backend.yaml"
+kubectl set image -n "$NAMESPACE" deployment/backend backend="$BACKEND_IMAGE"
+
+echo "==> Deploying frontend..."
+kubectl apply -n "$NAMESPACE" -f "$ROOT_DIR/k8s/frontend.yaml"
+kubectl set image -n "$NAMESPACE" deployment/frontend frontend="$FRONTEND_IMAGE"
+
+echo "==> Applying ingress..."
+kubectl apply -n "$NAMESPACE" -f "$ROOT_DIR/k8s/ingress.yaml"
+
+echo "==> Waiting for rollouts..."
+kubectl rollout status -n "$NAMESPACE" deployment/redis --timeout=120s
+kubectl rollout status -n "$NAMESPACE" deployment/backend --timeout=120s
+kubectl rollout status -n "$NAMESPACE" deployment/frontend --timeout=120s
+
+echo ""
+echo "==> Deployment complete!"
+kubectl get pods -n "$NAMESPACE"


### PR DESCRIPTION
- Add scripts/deploy.sh for building, pushing, and deploying to K8s
- Add .github/workflows/deploy.yml that builds Docker images, pushes to GHCR, and deploys to Kubernetes on push to main
- Add k8s/namespace.yaml for the clue namespace
- Fix frontend Dockerfile to use multi-stage build with nginx for production
- Fix backend Dockerfile CMD to use uvicorn instead of python main.py
- Add workflow_call trigger to CI so deploy workflow can reuse it
- Fix CI cache-dependency-path to use pyproject.toml (no requirements.txt)

https://claude.ai/code/session_01YVpEckHxicpVoAk6x2ChjE