### PR TITLE
Implement separate roll and move phases with secret passages

### DIFF
--- a/backend/app/agents.py
+++ b/backend/app/agents.py
@@ -13,7 +13,7 @@ from abc import ABC, abstractmethod
 
 import httpx
 
-from .game import SUSPECTS, WEAPONS, ROOMS
+from .game import SUSPECTS, WEAPONS, ROOMS, SECRET_PASSAGE_MAP
 from .board import (
     Room,
     build_grid,
@@ -203,8 +203,27 @@ class RandomAgent(BaseAgent):
             )
             return action
 
-        # Phase 1: move (dice not rolled yet)
-        if not dice_rolled and "move" in available:
+        # Phase 1a: use secret passage if available and destination is useful
+        if "secret_passage" in available:
+            my_room = current_room.get(player_id)
+            dest_room = SECRET_PASSAGE_MAP.get(my_room) if my_room else None
+            if dest_room and dest_room in unknown_rooms:
+                logger.info(
+                    "[%s:%s] Using secret passage from %s to %s",
+                    self.agent_type,
+                    player_id,
+                    my_room,
+                    dest_room,
+                )
+                return {"type": "secret_passage"}
+
+        # Phase 1b: roll dice
+        if "roll" in available:
+            logger.info("[%s:%s] Rolling dice", self.agent_type, player_id)
+            return {"type": "roll"}
+
+        # Phase 2: choose room to move toward (dice already rolled)
+        if "move" in available:
             player_pos = game_state.player_positions.get(player_id)
             target_room = self._pick_target_room(
                 unknown_rooms, current_room.get(player_id), player_pos
@@ -219,7 +238,7 @@ class RandomAgent(BaseAgent):
             )
             return {"type": "move", "room": target_room}
 
-        # Phase 2: suggest if in a room
+        # Phase 3: suggest if in a room
         room = current_room.get(player_id)
         if room and "suggest" in available:
             suspect = self._pick_unknown_or_random(unknown_suspects, SUSPECTS)
@@ -240,7 +259,7 @@ class RandomAgent(BaseAgent):
                 "room": room,
             }
 
-        # Phase 3: end turn
+        # Phase 4: end turn
         logger.info("[%s:%s] Ending turn", self.agent_type, player_id)
         return {"type": "end_turn"}
 
@@ -424,11 +443,12 @@ GAME ELEMENTS:
 - Suspects: Miss Scarlett, Colonel Mustard, Mrs. White, Reverend Green, Mrs. Peacock, Professor Plum
 - Weapons: Candlestick, Knife, Lead Pipe, Revolver, Rope, Wrench
 - Rooms: Kitchen, Ballroom, Conservatory, Billiard Room, Library, Study, Hall, Lounge, Dining Room
+- Secret passages: Study<->Kitchen, Lounge<->Conservatory
 
 RULES:
 - One suspect, one weapon, and one room form the secret solution.
 - Cards you hold or have been shown are NOT the solution.
-- On your turn: roll dice and move to a room, then optionally suggest or accuse.
+- On your turn: if in a corner room, you may use a secret passage; otherwise roll dice, then choose a room to move toward. After moving, optionally suggest or accuse.
 - Suggestions must use the room you are currently in.
 - Accuse ONLY when you are certain of all three solution cards.
 - A wrong accusation eliminates you from the game.
@@ -610,6 +630,13 @@ class LLMAgent(BaseAgent):
         lines.append("")
         lines.append("Choose your action. Valid action formats:")
 
+        if "secret_passage" in available:
+            passage_dest = SECRET_PASSAGE_MAP.get(current_room.get(player_id, ""), "?")
+            lines.append(
+                f'  Secret passage (to {passage_dest}): {{"type": "secret_passage"}}'
+            )
+        if "roll" in available:
+            lines.append('  Roll dice: {"type": "roll"}')
         if "move" in available:
             lines.append('  Move: {"type": "move", "room": "<room name>"}')
         if "suggest" in available:
@@ -664,6 +691,10 @@ class LLMAgent(BaseAgent):
                 available,
             )
             return False
+
+        if action_type in ("roll", "secret_passage", "end_turn"):
+            # No additional validation needed for these action types
+            return True
 
         if action_type == "move":
             room = action.get("room")

--- a/backend/app/models.py
+++ b/backend/app/models.py
@@ -49,6 +49,7 @@ class GameState(BaseModel):
     suggestions_this_turn: list[Suggestion] = Field(default_factory=list)
     winner: Optional[str] = None
     dice_rolled: bool = False
+    moved: bool = False
     last_roll: Optional[list[int]] = None
     pending_show_card: Optional[PendingShowCard] = None
 

--- a/backend/tests/test_game.py
+++ b/backend/tests/test_game.py
@@ -4,7 +4,7 @@ import pytest
 import pytest_asyncio
 import fakeredis.aioredis as fakeredis
 
-from app.game import ClueGame, SUSPECTS, WEAPONS, ROOMS, ALL_CARDS, ROOM_CENTERS
+from app.game import ClueGame, SUSPECTS, WEAPONS, ROOMS, ALL_CARDS, ROOM_CENTERS, SECRET_PASSAGE_MAP
 
 # ---------------------------------------------------------------------------
 # Fixtures
@@ -37,10 +37,11 @@ async def _add_two_players(game: ClueGame):
 
 
 async def _place_player_in_room(game: ClueGame, player_id: str, room: str):
-    """Directly place a player in a room and mark dice as rolled."""
+    """Directly place a player in a room and mark dice as rolled and moved."""
     state = await game._load_state()
     state.current_room[player_id] = room
     state.dice_rolled = True
+    state.moved = True
     state.last_roll = [6]
     center = ROOM_CENTERS.get(room)
     if center:
@@ -231,10 +232,12 @@ async def test_move_logging(game: ClueGame):
 
     whose_turn = state.whose_turn
     room = ROOMS[2]
+    # Roll first, then move
+    await game.process_action(whose_turn, {"type": "roll"})
     await game.process_action(whose_turn, {"type": "move", "room": room})
 
     log = await game.get_log()
-    # log[0] = game_started, log[1] = move
+    assert any(entry["type"] == "roll" for entry in log)
     assert any(entry["type"] == "move" for entry in log)
     move_entry = next(e for e in log if e["type"] == "move")
     assert move_entry["player_id"] == whose_turn
@@ -322,7 +325,7 @@ async def test_available_actions_waiting_state(game: ClueGame):
 
 
 @pytest.mark.asyncio
-async def test_available_actions_before_move(game: ClueGame):
+async def test_available_actions_before_roll(game: ClueGame):
     await _add_two_players(game)
     state = await game.start()
 
@@ -330,8 +333,9 @@ async def test_available_actions_before_move(game: ClueGame):
     not_turn = "P2" if whose_turn == "P1" else "P1"
 
     actions = game.get_available_actions(whose_turn, state)
-    assert "move" in actions
+    assert "roll" in actions
     assert "chat" in actions
+    assert "move" not in actions
     assert "suggest" not in actions
     assert "accuse" in actions
     assert "end_turn" in actions
@@ -515,5 +519,177 @@ async def test_player_state_includes_available_actions(game: ClueGame):
     whose_turn = state.whose_turn
     p_state = await game.get_player_state(whose_turn)
     assert p_state.available_actions is not None
-    assert "move" in p_state.available_actions
+    assert "roll" in p_state.available_actions
     assert "chat" in p_state.available_actions
+
+
+# ---------------------------------------------------------------------------
+# Turn flow: roll -> move tests
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_roll_then_move(game: ClueGame):
+    """Roll dice first, then choose a room to move toward."""
+    await _add_two_players(game)
+    state = await game.start()
+    whose_turn = state.whose_turn
+
+    # Before rolling: roll is available, move is not
+    actions = game.get_available_actions(whose_turn, state)
+    assert "roll" in actions
+    assert "move" not in actions
+
+    # Roll dice
+    result = await game.process_action(whose_turn, {"type": "roll"})
+    assert result["type"] == "roll"
+    assert "dice" in result
+    assert result["dice"] >= 1
+
+    # After rolling: move is available, roll is not
+    state = await game.get_state()
+    assert state.dice_rolled is True
+    assert state.moved is False
+    actions = game.get_available_actions(whose_turn, state)
+    assert "move" in actions
+    assert "roll" not in actions
+
+    # Choose a room
+    room = ROOMS[0]
+    move_result = await game.process_action(whose_turn, {"type": "move", "room": room})
+    assert move_result["type"] == "move"
+
+    # After moving: neither roll nor move available
+    state = await game.get_state()
+    assert state.moved is True
+    actions = game.get_available_actions(whose_turn, state)
+    assert "roll" not in actions
+    assert "move" not in actions
+
+
+@pytest.mark.asyncio
+async def test_cannot_move_without_rolling(game: ClueGame):
+    """Move should fail if dice haven't been rolled yet."""
+    await _add_two_players(game)
+    state = await game.start()
+    whose_turn = state.whose_turn
+
+    with pytest.raises(ValueError, match="not available at this time"):
+        await game.process_action(whose_turn, {"type": "move", "room": ROOMS[0]})
+
+
+@pytest.mark.asyncio
+async def test_cannot_roll_twice(game: ClueGame):
+    """Rolling dice twice in a turn should fail."""
+    await _add_two_players(game)
+    state = await game.start()
+    whose_turn = state.whose_turn
+
+    await game.process_action(whose_turn, {"type": "roll"})
+    with pytest.raises(ValueError, match="not available at this time"):
+        await game.process_action(whose_turn, {"type": "roll"})
+
+
+# ---------------------------------------------------------------------------
+# Secret passage tests
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_secret_passage_available_in_corner_room(game: ClueGame):
+    """Secret passage should be offered when player is in a corner room."""
+    await _add_two_players(game)
+    state = await game.start()
+    whose_turn = state.whose_turn
+
+    # Place player in Study (corner room with passage to Kitchen)
+    st = await game._load_state()
+    st.current_room[whose_turn] = "Study"
+    center = ROOM_CENTERS.get("Study")
+    if center:
+        st.player_positions[whose_turn] = list(center)
+    await game._save_state(st)
+
+    state = await game.get_state()
+    actions = game.get_available_actions(whose_turn, state)
+    assert "secret_passage" in actions
+    assert "roll" in actions
+
+
+@pytest.mark.asyncio
+async def test_secret_passage_not_available_in_non_corner_room(game: ClueGame):
+    """Secret passage should NOT be offered in non-corner rooms."""
+    await _add_two_players(game)
+    state = await game.start()
+    whose_turn = state.whose_turn
+
+    # Place player in Hall (no secret passage)
+    st = await game._load_state()
+    st.current_room[whose_turn] = "Hall"
+    center = ROOM_CENTERS.get("Hall")
+    if center:
+        st.player_positions[whose_turn] = list(center)
+    await game._save_state(st)
+
+    state = await game.get_state()
+    actions = game.get_available_actions(whose_turn, state)
+    assert "secret_passage" not in actions
+    assert "roll" in actions
+
+
+@pytest.mark.asyncio
+async def test_use_secret_passage(game: ClueGame):
+    """Using a secret passage should move the player and skip rolling."""
+    await _add_two_players(game)
+    state = await game.start()
+    whose_turn = state.whose_turn
+
+    # Place player in Study
+    st = await game._load_state()
+    st.current_room[whose_turn] = "Study"
+    center = ROOM_CENTERS.get("Study")
+    if center:
+        st.player_positions[whose_turn] = list(center)
+    await game._save_state(st)
+
+    result = await game.process_action(whose_turn, {"type": "secret_passage"})
+    assert result["type"] == "secret_passage"
+    assert result["from_room"] == "Study"
+    assert result["room"] == "Kitchen"
+
+    # Player is now in Kitchen, moved=True, can suggest
+    state = await game.get_state()
+    assert state.current_room[whose_turn] == "Kitchen"
+    assert state.moved is True
+    actions = game.get_available_actions(whose_turn, state)
+    assert "suggest" in actions
+    assert "roll" not in actions
+    assert "move" not in actions
+
+
+@pytest.mark.asyncio
+async def test_secret_passage_all_pairs(game: ClueGame):
+    """Verify all four secret passage routes work."""
+    for from_room, to_room in SECRET_PASSAGE_MAP.items():
+        redis = fakeredis.FakeRedis(decode_responses=True)
+        g = ClueGame(f"TEST_{from_room.replace(' ', '')}", redis)
+        await g.create()
+        await g.add_player("P1", "Alice", "human")
+        await g.add_player("P2", "Bob", "human")
+        state = await g.start()
+        whose_turn = state.whose_turn
+
+        st = await g._load_state()
+        st.current_room[whose_turn] = from_room
+        center = ROOM_CENTERS.get(from_room)
+        if center:
+            st.player_positions[whose_turn] = list(center)
+        await g._save_state(st)
+
+        result = await g.process_action(whose_turn, {"type": "secret_passage"})
+        assert result["room"] == to_room
+        assert result["from_room"] == from_room
+
+        state = await g.get_state()
+        assert state.current_room[whose_turn] == to_room
+        await redis.aclose()

--- a/backend/tests/test_ws_e2e.py
+++ b/backend/tests/test_ws_e2e.py
@@ -141,11 +141,12 @@ async def _connect_mock_ws(game_id: str, player_id: str) -> MockWebSocket:
 
 
 async def _place_in_room(redis, game_id: str, player_id: str, room: str):
-    """Directly place a player in a room and mark dice as rolled."""
+    """Directly place a player in a room and mark dice as rolled and moved."""
     game = ClueGame(game_id, redis)
     state = await game.get_state()
     state.current_room[player_id] = room
     state.dice_rolled = True
+    state.moved = True
     state.last_roll = [6]
     center = ROOM_CENTERS.get(room)
     if center:
@@ -333,10 +334,13 @@ class TestActionBroadcasts:
 
     @pytest.mark.asyncio
     async def test_move_broadcasts_player_moved(self, http, redis):
-        """A move action broadcasts player_moved to all connected players."""
+        """A roll+move action broadcasts player_moved to all connected players."""
         game_id, pid1, pid2, ws1, ws2, state = await self._setup_two_player_game(http)
         whose_turn = state["whose_turn"]
 
+        await _submit_action(http, game_id, whose_turn, {"type": "roll"})
+        ws1.drain()
+        ws2.drain()
         await _submit_action(
             http, game_id, whose_turn, {"type": "move", "room": "Kitchen"}
         )
@@ -401,6 +405,7 @@ class TestActionBroadcasts:
         whose_turn = state["whose_turn"]
         other_pid = pid2 if whose_turn == pid1 else pid1
 
+        await _submit_action(http, game_id, whose_turn, {"type": "roll"})
         await _submit_action(
             http, game_id, whose_turn, {"type": "move", "room": "Kitchen"}
         )
@@ -423,6 +428,7 @@ class TestActionBroadcasts:
         other_ws = ws2 if whose_turn == pid1 else ws1
         current_ws = ws1 if whose_turn == pid1 else ws2
 
+        await _submit_action(http, game_id, whose_turn, {"type": "roll"})
         await _submit_action(
             http, game_id, whose_turn, {"type": "move", "room": "Kitchen"}
         )
@@ -435,7 +441,7 @@ class TestActionBroadcasts:
         your_turn = [m for m in other_ws.sent if m["type"] == "your_turn"]
         assert len(your_turn) >= 1
         assert "available_actions" in your_turn[0]
-        assert "move" in your_turn[0]["available_actions"]
+        assert "roll" in your_turn[0]["available_actions"]
 
         # Current player should NOT receive your_turn
         cur_your_turn = [m for m in current_ws.sent if m["type"] == "your_turn"]
@@ -707,7 +713,7 @@ class TestChatIntegration:
 
     @pytest.mark.asyncio
     async def test_game_actions_generate_chat_messages(self, http, redis):
-        """Game actions (move, suggest, etc.) generate chat messages."""
+        """Game actions (roll, move, etc.) generate chat messages."""
         game_id = await _create_game(http)
         pid1 = await _join_game(http, game_id, "Agent-1")
         pid2 = await _join_game(http, game_id, "Agent-2")
@@ -717,13 +723,11 @@ class TestChatIntegration:
         ws1 = await _connect_mock_ws(game_id, pid1)
         ws1.drain()
 
-        await _submit_action(
-            http, game_id, whose_turn, {"type": "move", "room": "Kitchen"}
-        )
+        await _submit_action(http, game_id, whose_turn, {"type": "roll"})
 
         chat = [m for m in ws1.sent if m["type"] == "chat_message"]
         assert len(chat) >= 1
-        # Chat message should mention the roll; room only if reached
+        # Chat message should mention the roll
         assert "rolled" in chat[0]["text"]
 
 
@@ -1090,7 +1094,7 @@ class TestReconnection:
 
     @pytest.mark.asyncio
     async def test_reconnect_after_action_gets_updated_state(self, http, redis):
-        """A player connecting after a move sees the updated game state."""
+        """A player connecting after a roll sees the updated game state."""
         game_id = await _create_game(http)
         pid1 = await _join_game(http, game_id, "Agent-1")
         pid2 = await _join_game(http, game_id, "Agent-2")
@@ -1099,13 +1103,10 @@ class TestReconnection:
         state = await _get_state(http, game_id)
         whose_turn = state["whose_turn"]
 
-        # Make a move without any WS connections
-        await _submit_action(
-            http, game_id, whose_turn, {"type": "move", "room": "Kitchen"}
-        )
+        # Roll dice without any WS connections
+        await _submit_action(http, game_id, whose_turn, {"type": "roll"})
 
         # Now "connect" and verify state
-        # Simulate what the WS endpoint does on connect: send game_state
         game = ClueGame(game_id, redis)
         player_state = await game.get_player_state(pid1)
         assert player_state is not None
@@ -1130,14 +1131,11 @@ class TestReconnection:
         ws1_new = await _connect_mock_ws(game_id, pid1)
 
         whose_turn = state["whose_turn"]
-        await _submit_action(
-            http, game_id, whose_turn, {"type": "move", "room": "Kitchen"}
-        )
+        await _submit_action(http, game_id, whose_turn, {"type": "roll"})
 
         # New WS should have received the broadcast
-        moved = [m for m in ws1_new.sent if m["type"] == "player_moved"]
-        assert len(moved) >= 1
+        rolled = [m for m in ws1_new.sent if m["type"] == "dice_rolled"]
+        assert len(rolled) >= 1
 
         # Old WS should NOT have received it (disconnected)
-        # Since we drained nothing, just check the new one works
         assert len(ws1_new.sent) > 0

--- a/frontend/src/App.vue
+++ b/frontend/src/App.vue
@@ -182,12 +182,20 @@ function handleMessage(msg) {
       if (msg.available_actions) availableActions.value = msg.available_actions
       break
 
+    case 'dice_rolled':
+      if (gameState.value) {
+        gameState.value = { ...gameState.value, last_roll: msg.last_roll, dice_rolled: true }
+      }
+      break
+
     case 'player_moved':
       if (gameState.value) {
         const rooms = { ...gameState.value.current_room, [msg.player_id]: msg.room }
         const positions = { ...(gameState.value.player_positions || {}) }
         if (msg.position) positions[msg.player_id] = msg.position
-        gameState.value = { ...gameState.value, current_room: rooms, player_positions: positions, last_roll: [msg.dice, 0], dice_rolled: true }
+        const updates = { current_room: rooms, player_positions: positions, moved: true }
+        if (msg.dice) updates.last_roll = [msg.dice]
+        gameState.value = { ...gameState.value, ...updates }
       }
       break
 

--- a/frontend/src/components/GameBoard.vue
+++ b/frontend/src/components/GameBoard.vue
@@ -24,10 +24,6 @@
         <div v-if="isObserver" class="observer-badge">Observer</div>
         <div v-if="gameState?.last_roll" class="dice-display" title="Last dice roll">
           <span class="dice">{{ gameState.last_roll[0] }}</span>
-          <span class="dice-plus">+</span>
-          <span class="dice">{{ gameState.last_roll[1] }}</span>
-          <span class="dice-eq">=</span>
-          <span class="dice-total">{{ gameState.last_roll[0] + gameState.last_roll[1] }}</span>
         </div>
       </div>
     </header>
@@ -112,16 +108,33 @@
         <section v-if="isMyTurn && !showCardRequest && gameState?.status === 'playing' && !isObserver" class="sidebar-panel actions-panel">
           <h2>Actions</h2>
 
-          <!-- Move -->
+          <!-- Secret Passage -->
+          <div v-if="canSecretPassage" class="action-group">
+            <h3>Secret Passage</h3>
+            <p class="action-hint">You're in {{ myCurrentRoom }} — take the secret passage?</p>
+            <button class="action-btn passage-btn" @click="doSecretPassage">
+              Use Passage to {{ passageDestination }}
+            </button>
+          </div>
+
+          <!-- Roll Dice -->
+          <div v-if="canRoll" class="action-group">
+            <h3>Roll Dice</h3>
+            <button class="action-btn roll-btn" @click="doRoll">
+              Roll Dice
+            </button>
+          </div>
+
+          <!-- Move (choose room after rolling) -->
           <div v-if="canMove" class="action-group">
-            <h3>Move</h3>
+            <h3>Move (rolled {{ gameState?.last_roll?.[0] }})</h3>
             <p class="action-hint">Click a room on the board or select below:</p>
             <select v-model="targetRoom" class="action-select">
               <option value="">-- Choose a room --</option>
               <option v-for="room in ROOMS" :key="room" :value="room">{{ room }}</option>
             </select>
             <button class="action-btn move-btn" :disabled="!targetRoom" @click="doMove">
-              Roll &amp; Move{{ targetRoom ? ' to ' + targetRoom : '' }}
+              Move{{ targetRoom ? ' to ' + targetRoom : '' }}
             </button>
           </div>
 
@@ -264,10 +277,20 @@ const showAccuseForm = ref(false)
 const isMyTurn = computed(() => props.gameState?.whose_turn === props.playerId)
 const myCurrentRoom = computed(() => props.gameState?.current_room?.[props.playerId] ?? null)
 
+const canSecretPassage = computed(() => props.availableActions.includes('secret_passage'))
+const canRoll = computed(() => props.availableActions.includes('roll'))
 const canMove = computed(() => props.availableActions.includes('move'))
 const canSuggest = computed(() => props.availableActions.includes('suggest'))
 const canAccuse = computed(() => props.availableActions.includes('accuse'))
 const canEndTurn = computed(() => props.availableActions.includes('end_turn'))
+
+const SECRET_PASSAGES = {
+  'Study': 'Kitchen',
+  'Kitchen': 'Study',
+  'Lounge': 'Conservatory',
+  'Conservatory': 'Lounge',
+}
+const passageDestination = computed(() => SECRET_PASSAGES[myCurrentRoom.value] ?? '?')
 
 const currentPlayerName = computed(() => {
   return playerName(props.gameState?.whose_turn)
@@ -317,6 +340,14 @@ function onRoomSelected(room) {
   if (canMove.value) {
     targetRoom.value = room
   }
+}
+
+function doSecretPassage() {
+  emit('action', { type: 'secret_passage' })
+}
+
+function doRoll() {
+  emit('action', { type: 'roll' })
 }
 
 function doMove() {
@@ -778,6 +809,24 @@ watch(
 .action-btn:disabled {
   opacity: 0.4;
   cursor: not-allowed;
+}
+
+.passage-btn {
+  background: #8e44ad;
+  color: #fff;
+}
+
+.passage-btn:hover {
+  background: #7d3c98;
+}
+
+.roll-btn {
+  background: #c9a84c;
+  color: #1a1a2e;
+}
+
+.roll-btn:hover {
+  background: #d4b85c;
 }
 
 .move-btn {


### PR DESCRIPTION
## Summary
Refactored the turn flow to separate dice rolling from movement, and added support for secret passages in corner rooms. Players must now explicitly roll dice before choosing a room to move toward, providing more strategic gameplay.

## Key Changes

### Turn Flow Restructuring
- Split movement into two distinct phases:
  - **Phase 1 (Pre-roll)**: Player can use a secret passage (if in corner room) or roll dice
  - **Phase 2 (Post-roll)**: Player chooses a room to move toward using the rolled dice
  - **Phase 3 (Post-move)**: Player can suggest or accuse
- Added `moved` boolean to `GameState` to track whether a player has moved this turn
- Updated `get_available_actions()` to enforce the new phase-based action availability

### Secret Passages
- Imported `SECRET_PASSAGES` from board module and created `SECRET_PASSAGE_MAP` for easy lookup
- Implemented `_handle_secret_passage()` to instantly move players between linked corner rooms (Study↔Kitchen, Lounge↔Conservatory)
- Secret passages skip the dice roll requirement and mark the player as moved
- Added UI components for secret passage selection with visual indication of destination

### Dice Rolling
- Extracted dice rolling into separate `_handle_roll()` action handler
- Roll action now broadcasts `dice_rolled` event to all players
- Players can no longer move without rolling first (enforced with validation)
- Players cannot roll twice in a single turn

### Frontend Updates
- Separated "Roll Dice" and "Move" buttons in the actions panel
- Updated dice display to show only the single roll value (removed dual dice display)
- Added secret passage button with destination preview
- Updated action hints to clarify the two-phase process

### Backend Broadcasting
- Added `dice_rolled` message type for roll-only actions
- Updated `player_moved` broadcast to distinguish between regular moves and secret passages
- Chat messages now separately announce rolls and moves

### AI Agent Updates
- Updated agent decision logic to handle the new three-phase turn structure
- Agents now check for secret passage opportunities before rolling
- Updated action validation and prompt building for new action types

## Implementation Details
- The `moved` flag is reset at the start of each turn in `_handle_end_turn()`
- Secret passages are only available when a player is in a corner room (checked via `SECRET_PASSAGE_MAP`)
- Move validation now requires `dice_rolled=True` and `moved=False`
- All game state updates are persisted to Redis and logged appropriately

https://claude.ai/code/session_012m9sS9ufJCQhE1B6aXHKud