### PR TITLE
Add character personality chat system for agents

### DIFF
--- a/backend/app/game.py
+++ b/backend/app/game.py
@@ -160,7 +160,7 @@ class ClueGame:
         2. Post-roll: offer move (choose room)
         3. Post-move: offer suggest (if in a room), accuse, end_turn
         """
-        actions = ["chat"]
+        actions = []
 
         if state.status != "playing":
             return actions

--- a/backend/tests/test_game.py
+++ b/backend/tests/test_game.py
@@ -326,7 +326,7 @@ async def test_available_actions_waiting_state(game: ClueGame):
     await _add_two_players(game)
     state = await game.get_state()
     actions = game.get_available_actions("P1", state)
-    assert actions == ["chat"]
+    assert actions == []
 
 
 @pytest.mark.asyncio
@@ -339,15 +339,14 @@ async def test_available_actions_before_roll(game: ClueGame):
 
     actions = game.get_available_actions(whose_turn, state)
     assert "roll" in actions
-    assert "chat" in actions
     assert "move" not in actions
     assert "suggest" not in actions
     assert "accuse" in actions
     assert "end_turn" in actions
 
-    # Other player can only chat
+    # Other player has no actions available
     other_actions = game.get_available_actions(not_turn, state)
-    assert other_actions == ["chat"]
+    assert other_actions == []
 
 
 @pytest.mark.asyncio
@@ -366,7 +365,6 @@ async def test_available_actions_after_move_in_room(game: ClueGame):
     assert "accuse" in actions
     assert "end_turn" in actions
     assert "move" not in actions
-    assert "chat" in actions
 
 
 @pytest.mark.asyncio
@@ -398,14 +396,13 @@ async def test_available_actions_after_suggest_pending_show(game: ClueGame):
 
     state = await game.get_state()
 
-    # Suggesting player can only chat while waiting
+    # Suggesting player has no actions while waiting
     turn_actions = game.get_available_actions(whose_turn, state)
-    assert turn_actions == ["chat"]
+    assert turn_actions == []
 
     # The player who must show a card gets show_card action
     other_actions = game.get_available_actions(other_id, state)
     assert "show_card" in other_actions
-    assert "chat" in other_actions
 
 
 @pytest.mark.asyncio
@@ -525,7 +522,6 @@ async def test_player_state_includes_available_actions(game: ClueGame):
     p_state = await game.get_player_state(whose_turn)
     assert p_state.available_actions is not None
     assert "roll" in p_state.available_actions
-    assert "chat" in p_state.available_actions
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
This PR adds an in-character chat system for AI agents in the Clue game, allowing each character to send personality-driven messages during gameplay actions. The system includes per-character message templates, probability-based chat generation, and LLM integration for dynamic chat responses.

## Key Changes

- **Character Personality Chat Templates**: Added comprehensive `CHARACTER_CHAT` dictionary with action-specific message templates for all six Clue characters (Miss Scarlett, Colonel Mustard, Mrs. White, Reverend Green, Mrs. Peacock, Professor Plum), each with distinct voice and mannerisms.

- **Chat Generation System**: Implemented `generate_chat()` method in the `Agent` base class that:
  - Checks per-action probability thresholds before generating messages
  - Selects random templates from character-specific sets
  - Formats templates with game context (dice rolls, room names, suspects, weapons)
  - Falls back to generic messages for unknown characters

- **LLM Integration**: Enhanced the LLM system prompt to:
  - Include character personality blurbs injected via `_CHARACTER_PERSONALITY_BLURBS`
  - Request chat messages in JSON responses alongside action decisions
  - Extract and stash LLM-generated chat for later broadcast

- **Chat Broadcasting**: Modified `_run_agent_loop()` in main.py to broadcast personality chat messages after actions, including special handling for show_card actions.

- **Character Assignment**: Updated agent initialization to assign and display character names, replacing placeholder names with actual character identities for better personality immersion.

- **Removed Chat Action**: Removed "chat" from available actions list since chat is now generated automatically rather than being a player-selectable action.

## Implementation Details

- Chat templates use optional format placeholders (`{dice}`, `{room}`, `{suspect}`, `{weapon}`) that are silently ignored if missing via the `_format_chat()` helper function
- Probability thresholds vary by action type (e.g., 1.0 for suggestions/accusations, 0.3 for end_turn)
- LLM responses can override template-based chat via the `_pending_chat` mechanism
- Character personality is maintained consistently across both template-based and LLM-generated messages

https://claude.ai/code/session_018z32BAPU8LRmcpkg9kseGP