### PR TITLE
Fix room context fallback logic in agent personality chat

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -557,7 +557,7 @@ async def _run_agent_loop(game_id: str):
                 # Broadcast personality chat after the action
                 chat_context = {
                     "dice": result.get("dice", ""),
-                    "room": result.get("room", action.get("room", "")),
+                    "room": result.get("room") or action.get("room") or "",
                     "suspect": action.get("suspect", ""),
                     "weapon": action.get("weapon", ""),
                 }


### PR DESCRIPTION
## Summary
Fixed the room context fallback logic when broadcasting personality chat messages in the agent loop to properly handle cases where the room value may be falsy.

## Key Changes
- Updated the room context assignment to use a more robust fallback chain: `result.get("room") or action.get("room") or ""`
- This replaces the previous nested `get()` calls which didn't properly handle falsy values (empty strings, None, etc.)

## Implementation Details
The change ensures that if `result.get("room")` returns a falsy value, the code will fall back to `action.get("room")`, and finally to an empty string if both are falsy. This is more reliable than the previous approach which would have used an empty string from `result.get("room", "")` even if that value was explicitly set to a falsy value in the result.

https://claude.ai/code/session_017djyZHfwoMnTvRPTQSBJ9s