### PR TITLE
Style seen cards with gray text and show who revealed them on hover

### DIFF
--- a/frontend/src/components/DetectiveNotes.vue
+++ b/frontend/src/components/DetectiveNotes.vue
@@ -9,6 +9,7 @@
         :key="card"
         class="note-row"
         :class="noteClass(card)"
+        :title="noteTitle(card)"
         @click="cycleNote(card)"
       >
         <span class="note-card">{{ card }}</span>
@@ -23,6 +24,7 @@
         :key="card"
         class="note-row"
         :class="noteClass(card)"
+        :title="noteTitle(card)"
         @click="cycleNote(card)"
       >
         <span class="note-card">{{ card }}</span>
@@ -37,6 +39,7 @@
         :key="card"
         class="note-row"
         :class="noteClass(card)"
+        :title="noteTitle(card)"
         @click="cycleNote(card)"
       >
         <span class="note-card">{{ card }}</span>
@@ -62,6 +65,8 @@ const props = defineProps({
 
 // notes: card -> state string
 const notes = reactive({})
+// Track who showed each card
+const shownByMap = reactive({})
 
 // Auto-mark cards in hand
 watch(
@@ -103,10 +108,17 @@ function cycleNote(card) {
 }
 
 // Expose for parent to programmatically mark cards
-function markCard(card, state) {
+function markCard(card, state, shownBy) {
   if (notes[card] !== 'have') {
     notes[card] = state
+    if (shownBy) shownByMap[card] = shownBy
   }
+}
+
+function noteTitle(card) {
+  const state = notes[card] ?? ''
+  if (state === 'seen' && shownByMap[card]) return `Shown by ${shownByMap[card]}`
+  return ''
 }
 
 defineExpose({ markCard })
@@ -173,6 +185,10 @@ h4 {
 
 .note-have .note-mark {
   color: #2ecc71;
+}
+
+.note-seen {
+  color: #888;
 }
 
 .note-seen .note-mark {

--- a/frontend/src/components/GameBoard.vue
+++ b/frontend/src/components/GameBoard.vue
@@ -438,7 +438,7 @@ watch(
   () => props.cardShown,
   (shown) => {
     if (shown?.card && notesRef.value) {
-      notesRef.value.markCard(shown.card, 'seen')
+      notesRef.value.markCard(shown.card, 'seen', playerName(shown.by))
     }
   }
 )


### PR DESCRIPTION
Cards marked with the eye emoji in detective notes now render with gray text. Hovering over a seen card shows a tooltip with the name of the player who showed it.

https://claude.ai/code/session_011af336wQEh4uTWyGLmSQWP