### PR TITLE
Show actual dice roll value in LLM agent prompt

### DIFF
--- a/backend/app/agents.py
+++ b/backend/app/agents.py
@@ -1282,7 +1282,7 @@ class LLMAgent(BaseAgent):
             f"- Unknown weapons (could be solution): {unknown_weapons}",
             f"- Unknown rooms (could be solution): {unknown_rooms}",
             f"- Your current room: {current_room.get(player_id, 'none')}",
-            f"- Dice rolled this turn: {dice_rolled}",
+            f"- Dice roll: {game_state.last_roll[0] if game_state.last_roll else 'not rolled yet'}",
             f"- Available actions: {available}",
         ]
 


### PR DESCRIPTION
Change "Dice rolled this turn: True/False" to show the actual roll value (e.g. "Dice roll: 4") or "not rolled yet" when no roll has been made. This gives agents more useful information about their current turn state.

https://claude.ai/code/session_01D3cD3Bao1VMf1tseNLHVdu