### PR TITLE
Fix auto-end timer cancelling itself before ending the turn

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -133,6 +133,10 @@ async def _auto_end_turn_task(game_id: str, player_id: str, turn_number: int):
     """Wait AUTO_END_TURN_SECONDS then auto-end the player's turn if still valid."""
     try:
         await asyncio.sleep(AUTO_END_TURN_SECONDS)
+        # Remove ourselves from the timer dict BEFORE calling _execute_action,
+        # otherwise _execute_action -> _cancel_auto_end_timer will cancel this
+        # running task, causing CancelledError before the end_turn completes.
+        _auto_end_timers.pop(game_id, None)
         game = ClueGame(game_id, redis_client)
         state = await game.get_state()
         if (


### PR DESCRIPTION
The auto-end timer task called _execute_action(), which unconditionally calls _cancel_auto_end_timer(). This cancelled the currently running task, raising CancelledError at the next await before the end_turn action could complete. Fix by popping the task from _auto_end_timers before calling _execute_action so the cancellation has nothing to find.

https://claude.ai/code/session_01VvoHqCZRqs1BFbaLh8oo6R