### PR TITLE
Add hover state to hallway squares only when reachable

### DIFF
--- a/backend/app/game.py
+++ b/backend/app/game.py
@@ -8,6 +8,7 @@ from .board import (
     ROOM_CENTERS,
     SECRET_PASSAGES,
     Room,
+    SquareType,
     build_grid,
     build_graph,
     reachable,
@@ -197,6 +198,29 @@ class ClueGame:
             actions.append("end_turn")
 
         return actions
+
+    def get_reachable_positions(self, player_id: str, state: GameState) -> list:
+        """Return reachable hallway positions as [row, col] pairs for the player."""
+        if not state.dice_rolled or state.moved:
+            return []
+        total = state.last_roll[0] if state.last_roll else 0
+        current_room_name = state.current_room.get(player_id)
+        pos = state.player_positions.get(player_id)
+        if current_room_name and current_room_name in _ROOM_NAME_TO_ENUM:
+            start_sq = _ROOM_NODES[_ROOM_NAME_TO_ENUM[current_room_name]]
+        elif pos:
+            start_sq = _SQUARES.get((pos[0], pos[1]))
+        else:
+            return []
+        reached = reachable(start_sq, total, _SQUARES, _ROOM_NODES)
+        positions = []
+        for sq in reached:
+            if sq.type == SquareType.ROOM:
+                continue
+            if sq == start_sq:
+                continue
+            positions.append([sq.row, sq.col])
+        return positions
 
     async def get_player_state(self, player_id: str) -> PlayerState | None:
         state = await self._load_state()

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -229,6 +229,7 @@ async def _execute_action(game_id: str, player_id: str, action: dict) -> dict:
             {
                 "type": "your_turn",
                 "available_actions": game.get_available_actions(player_id, state),
+                "reachable_positions": game.get_reachable_positions(player_id, state),
             },
         )
 

--- a/frontend/src/App.vue
+++ b/frontend/src/App.vue
@@ -27,6 +27,7 @@
       :chat-messages="chatMessages"
       :is-observer="isObserver"
       :auto-end-timer="autoEndTimer"
+      :reachable-positions="reachablePositions"
       @action="sendAction"
       @send-chat="sendChat"
       @dismiss-card-shown="cardShown = null"
@@ -51,6 +52,7 @@ const chatMessages = ref([])
 const isObserver = ref(false)
 const urlGameId = ref(null)
 const autoEndTimer = ref(null)
+const reachablePositions = ref([])
 
 const gameStatus = computed(() => gameState.value?.status ?? 'waiting')
 const players = computed(() => gameState.value?.players ?? [])
@@ -150,6 +152,7 @@ function handleMessage(msg) {
         gameState.value = { ...gameState.value, ...fields }
       }
       autoEndTimer.value = null
+      reachablePositions.value = []
       break
 
     case 'player_joined':
@@ -172,6 +175,7 @@ function handleMessage(msg) {
 
     case 'your_turn':
       if (msg.available_actions) availableActions.value = msg.available_actions
+      reachablePositions.value = msg.reachable_positions ?? []
       showCardRequest.value = null
       autoEndTimer.value = null
       break
@@ -205,6 +209,7 @@ function handleMessage(msg) {
         if (msg.dice) updates.last_roll = [msg.dice]
         gameState.value = { ...gameState.value, ...updates }
       }
+      reachablePositions.value = []
       break
 
     case 'suggestion_made':
@@ -278,6 +283,7 @@ function resetState() {
   gameState.value = null
   yourCards.value = []
   availableActions.value = []
+  reachablePositions.value = []
   showCardRequest.value = null
   cardShown.value = null
   chatMessages.value = []

--- a/frontend/src/components/BoardMap.vue
+++ b/frontend/src/components/BoardMap.vue
@@ -178,6 +178,7 @@ const props = defineProps({
   playerId: String,
   selectedRoom: String,
   selectable: Boolean,
+  reachablePositions: { type: Array, default: () => [] },
 })
 
 const emit = defineEmits(['select-room', 'select-position'])
@@ -185,6 +186,14 @@ const emit = defineEmits(['select-room', 'select-position'])
 const cells = CELL_DATA
 
 const currentRoom = computed(() => props.gameState?.current_room?.[props.playerId] ?? null)
+
+const reachableSet = computed(() => {
+  const s = new Set()
+  for (const pos of props.reachablePositions) {
+    s.add(`${pos[0]},${pos[1]}`)
+  }
+  return s
+})
 
 const roomLabels = computed(() => Object.values(ROOM_INFO))
 
@@ -248,7 +257,10 @@ function cellClasses(cell) {
     if (props.selectedRoom === cell.room) cls.push('selected')
     if (currentRoom.value === cell.room) cls.push('my-room')
   } else if ((cell.type === 'hallway' || cell.type === 'start') && props.selectable) {
-    cls.push('clickable')
+    const key = `${cell.row},${cell.col}`
+    if (reachableSet.value.size === 0 || reachableSet.value.has(key)) {
+      cls.push('clickable')
+    }
   }
   return cls
 }
@@ -265,7 +277,10 @@ function handleCellClick(cell) {
   if (cell.room) {
     emit('select-room', cell.room)
   } else if (cell.type === 'hallway' || cell.type === 'start') {
-    emit('select-position', [cell.row, cell.col])
+    const key = `${cell.row},${cell.col}`
+    if (reachableSet.value.size === 0 || reachableSet.value.has(key)) {
+      emit('select-position', [cell.row, cell.col])
+    }
   }
 }
 

--- a/frontend/src/components/GameBoard.vue
+++ b/frontend/src/components/GameBoard.vue
@@ -38,6 +38,7 @@
           :player-id="playerId"
           :selected-room="targetRoom"
           :selectable="canMove"
+          :reachable-positions="reachablePositions"
           @select-room="onRoomSelected"
           @select-position="onPositionSelected"
         />
@@ -273,6 +274,7 @@ const props = defineProps({
   chatMessages: { type: Array, default: () => [] },
   isObserver: { type: Boolean, default: false },
   autoEndTimer: { type: Object, default: null },
+  reachablePositions: { type: Array, default: () => [] },
 })
 
 const emit = defineEmits(['action', 'send-chat', 'dismiss-card-shown'])


### PR DESCRIPTION
Compute reachable positions after dice roll via BFS on the backend and send them to the active player in the your_turn message. The frontend BoardMap now only applies the clickable/hover class to hallway cells that are within the reachable set, so unreachable squares no longer show a pointer cursor or highlight on hover.

https://claude.ai/code/session_01FoxXjvoZtMBTa4F9gQfFKK