### PR TITLE
Add memory persistence for LLM agents across game turns

### DIFF
--- a/backend/app/agents.py
+++ b/backend/app/agents.py
@@ -1034,7 +1034,16 @@ RULES:
 
 Respond with a valid JSON object for your chosen action. Include a "chat" field \
 with a short in-character comment about what you're doing (one sentence, stay in \
-character as {character}). Example: {{"type": "roll", "chat": "Let's see what fate has in store!"}}\
+character as {character}).
+
+Also include a "memory" field with your private detective notes — deductions, \
+suspicions, which cards you've eliminated, your strategy for next turns. These \
+notes will be shown back to you on your next turn so you can remember your \
+reasoning. Be concise but thorough. Example:
+
+{{"type": "roll", "chat": "Let's see what fate has in store!", "memory": "I know \
+Mrs. White and Rope are not the solution (in my hand). Colonel Mustard showed me \
+the Kitchen card. I should investigate the Study next."}}\
 """
 
 # Personality blurbs injected into the LLM system prompt per character.
@@ -1100,13 +1109,16 @@ class LLMAgent(BaseAgent):
 
     agent_type = "llm"
 
-    def __init__(self):
+    def __init__(self, redis_client=None, game_id: str = ""):
         super().__init__()
         self.api_url = os.getenv(
             "LLM_API_URL", "https://api.openai.com/v1/chat/completions"
         )
         self.api_key = os.getenv("LLM_API_KEY", "")
         self.model = os.getenv("LLM_MODEL", "gpt-5-mini")
+        self.memory: list[str] = []
+        self._redis = redis_client
+        self._game_id = game_id
 
         # Fallback agent shares our observation state
         self._fallback = RandomAgent()
@@ -1126,6 +1138,29 @@ class LLMAgent(BaseAgent):
             self.model,
             bool(self.api_key),
         )
+
+    async def load_memory(self):
+        """Load memory from Redis into the in-memory list."""
+        if self._redis and self._game_id and self.player_id:
+            from .game import ClueGame
+
+            game = ClueGame(self._game_id, self._redis)
+            self.memory = await game.get_memory(self.player_id)
+            logger.info(
+                "[%s:%s] Loaded %d memory entries from Redis",
+                self.agent_type,
+                self.player_id,
+                len(self.memory),
+            )
+
+    async def _save_memory_entry(self, entry: str):
+        """Append a memory entry both in-memory and to Redis."""
+        self.memory.append(entry)
+        if self._redis and self._game_id and self.player_id:
+            from .game import ClueGame
+
+            game = ClueGame(self._game_id, self._redis)
+            await game.append_memory(self.player_id, entry)
 
     # ------------------------------------------------------------------
     # LLM communication
@@ -1301,6 +1336,13 @@ class LLMAgent(BaseAgent):
                 f"{self.unrefuted_suggestions}"
             )
 
+        # Include memory from previous turns
+        if self.memory:
+            lines.append("")
+            lines.append("YOUR PRIVATE NOTES FROM PREVIOUS TURNS:")
+            for i, entry in enumerate(self.memory, 1):
+                lines.append(f"  Turn {i}: {entry}")
+
         lines.append("")
         lines.append("Choose your action. Valid action formats:")
 
@@ -1473,14 +1515,16 @@ class LLMAgent(BaseAgent):
                     player_id,
                     parsed,
                 )
-                # Extract chat message before validation (it's not a game field)
+                # Extract chat and memory before validation (not game fields)
                 llm_chat = parsed.pop("chat", None)
+                llm_memory = parsed.pop("memory", None)
                 logger.info(
-                    "[%s:%s] LLM proposed action fields | action=%s | chat_present=%s",
+                    "[%s:%s] LLM proposed action fields | action=%s | chat_present=%s | memory_present=%s",
                     self.agent_type,
                     player_id,
                     parsed,
                     isinstance(llm_chat, str) and bool(llm_chat.strip()),
+                    isinstance(llm_memory, str) and bool(llm_memory.strip()),
                 )
                 if llm_chat and isinstance(llm_chat, str):
                     llm_trace_logger.info(
@@ -1488,6 +1532,13 @@ class LLMAgent(BaseAgent):
                         self.agent_type,
                         player_id,
                         _clip_text(llm_chat, limit=400),
+                    )
+                if llm_memory and isinstance(llm_memory, str):
+                    llm_trace_logger.info(
+                        "[%s:%s] LLM memory note: %s",
+                        self.agent_type,
+                        player_id,
+                        _clip_text(llm_memory, limit=400),
                     )
                 if self._validate_action(parsed, available, game_state, player_state):
                     logger.info(
@@ -1500,6 +1551,9 @@ class LLMAgent(BaseAgent):
                     # Stash chat for generate_chat() to return later
                     if llm_chat and isinstance(llm_chat, str):
                         self._pending_chat = llm_chat
+                    # Save memory entry if provided
+                    if llm_memory and isinstance(llm_memory, str):
+                        await self._save_memory_entry(llm_memory.strip())
                     # Track rooms for suggestion
                     if parsed.get("type") == "suggest":
                         room = parsed.get("room")

--- a/backend/app/game.py
+++ b/backend/app/game.py
@@ -88,6 +88,9 @@ class ClueGame:
     def _cards_key(self, player_id: str) -> str:
         return f"game:{self.game_id}:cards:{player_id}"
 
+    def _memory_key(self, player_id: str) -> str:
+        return f"game:{self.game_id}:memory:{player_id}"
+
     # ------------------------------------------------------------------
     # Internal Redis helpers
     # ------------------------------------------------------------------
@@ -120,6 +123,16 @@ class ClueGame:
     async def _append_log(self, entry: dict):
         await self.redis.rpush(self._log_key, json.dumps(entry))
         await self.redis.expire(self._log_key, EXPIRY)
+
+    async def append_memory(self, player_id: str, entry: str):
+        """Append a memory entry for an LLM agent."""
+        await self.redis.rpush(self._memory_key(player_id), entry)
+        await self.redis.expire(self._memory_key(player_id), EXPIRY)
+
+    async def get_memory(self, player_id: str) -> list[str]:
+        """Retrieve all memory entries for an LLM agent."""
+        entries = await self.redis.lrange(self._memory_key(player_id), 0, -1)
+        return [e if isinstance(e, str) else e.decode() for e in entries]
 
     async def add_chat_message(self, message: ChatMessage):
         await self.redis.rpush(self._chat_key, message.model_dump_json())

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -763,7 +763,9 @@ async def start_game(game_id: str):
             pid = player.id
             ptype = player.type
             if ptype == "llm_agent":
-                agent: BaseAgent = LLMAgent()
+                agent: BaseAgent = LLMAgent(
+                    redis_client=redis_client, game_id=game_id
+                )
             elif ptype == "wanderer":
                 agent = WandererAgent()
             else:
@@ -772,6 +774,8 @@ async def start_game(game_id: str):
             agent.player_id = pid
             cards = await game._load_player_cards(pid)
             agent.observe_own_cards(cards)
+            if ptype == "llm_agent":
+                await agent.load_memory()
             agents[pid] = agent
             logger.info(
                 "Created %s agent for player %s (%s) in game %s",

--- a/backend/tests/test_game.py
+++ b/backend/tests/test_game.py
@@ -696,3 +696,34 @@ async def test_secret_passage_all_pairs(game: ClueGame):
         state = await g.get_state()
         assert state.current_room[whose_turn] == to_room
         await redis.aclose()
+
+
+# ---------------------------------------------------------------------------
+# Memory tests
+# ---------------------------------------------------------------------------
+
+
+async def test_memory_empty_initially(game):
+    """Memory for a player starts empty."""
+    entries = await game.get_memory("player1")
+    assert entries == []
+
+
+async def test_memory_append_and_retrieve(game):
+    """Appending memory entries persists and retrieves them in order."""
+    await game.append_memory("player1", "I suspect Colonel Mustard.")
+    await game.append_memory("player1", "Kitchen card has been shown to me.")
+
+    entries = await game.get_memory("player1")
+    assert len(entries) == 2
+    assert entries[0] == "I suspect Colonel Mustard."
+    assert entries[1] == "Kitchen card has been shown to me."
+
+
+async def test_memory_per_player(game):
+    """Each player has their own separate memory."""
+    await game.append_memory("player1", "Note for player 1")
+    await game.append_memory("player2", "Note for player 2")
+
+    assert await game.get_memory("player1") == ["Note for player 1"]
+    assert await game.get_memory("player2") == ["Note for player 2"]


### PR DESCRIPTION
## Summary
This PR adds a memory system that allows LLM agents to persist and recall their reasoning across multiple game turns. Agents can now record "private detective notes" about their deductions, suspicions, and strategy, which are stored in Redis and provided back to them on subsequent turns.

## Key Changes

- **Memory Storage in Redis**: Added `append_memory()` and `get_memory()` methods to `ClueGame` class to persist player memory entries in Redis with automatic expiry
- **LLMAgent Memory Integration**: 
  - Updated `LLMAgent.__init__()` to accept `redis_client` and `game_id` parameters
  - Added `load_memory()` method to retrieve stored memory entries at game start
  - Added `_save_memory_entry()` method to persist new memory entries to Redis
  - Added in-memory `memory` list to track entries during the game session
- **LLM Prompt Enhancement**: Updated the action decision prompt to:
  - Request a "memory" field in addition to "chat" in LLM responses
  - Include previous turn notes in the prompt so agents can reference their past reasoning
  - Provide example format showing how to structure memory entries
- **Action Processing**: Modified `decide_action()` to extract, log, and persist the "memory" field from LLM responses
- **Game Initialization**: Updated `start_game()` in main.py to pass Redis client and game ID to LLMAgent, and call `load_memory()` during agent setup
- **Test Coverage**: Added three new tests verifying memory functionality (empty initial state, append/retrieve, per-player isolation)

## Implementation Details

- Memory entries are stored as Redis lists with the key pattern `game:{game_id}:memory:{player_id}`
- Memory is loaded once at game start and maintained in-memory during gameplay
- New entries are saved both to the in-memory list and to Redis immediately when provided by the LLM
- Memory entries are included in the action prompt with turn numbering for clarity
- All memory operations include logging for debugging and tracing

https://claude.ai/code/session_014wbyLQ3J2PZZKwpwwGhKXr