### PR TITLE
Add reachable room/position highlighting for movement

### DIFF
--- a/backend/app/game.py
+++ b/backend/app/game.py
@@ -8,6 +8,7 @@ from .board import (
     ROOM_CENTERS,
     SECRET_PASSAGES,
     Room,
+    SquareType,
     build_grid,
     build_graph,
     reachable,
@@ -304,6 +305,44 @@ class ClueGame:
 
     def roll_dice(self) -> int:
         return random.randint(1, 6)
+
+    def get_reachable_targets(
+        self, player_id: str, state: "GameState", dice: int
+    ) -> dict:
+        """Compute which rooms and hallway squares are reachable with the given dice roll.
+
+        Returns a dict with:
+          - reachable_rooms: list of room names the player can enter
+          - reachable_positions: list of [row, col] hallway positions reachable
+        """
+        current_room_name = state.current_room.get(player_id)
+        pos = state.player_positions.get(player_id)
+
+        if current_room_name and current_room_name in _ROOM_NAME_TO_ENUM:
+            start_sq = _ROOM_NODES[_ROOM_NAME_TO_ENUM[current_room_name]]
+        elif pos:
+            start_sq = _SQUARES.get((pos[0], pos[1]))
+        else:
+            return {"reachable_rooms": list(ROOMS), "reachable_positions": []}
+
+        if not start_sq:
+            return {"reachable_rooms": list(ROOMS), "reachable_positions": []}
+
+        reached = reachable(start_sq, dice, _SQUARES, _ROOM_NODES)
+
+        rooms = []
+        positions = []
+        for sq, dist in reached.items():
+            if sq.type == SquareType.ROOM and sq.room:
+                rooms.append(sq.room.value)
+            elif sq != start_sq and sq.type in (
+                SquareType.HALLWAY,
+                SquareType.DOOR,
+                SquareType.START,
+            ):
+                positions.append([sq.row, sq.col])
+
+        return {"reachable_rooms": rooms, "reachable_positions": positions}
 
     async def process_action(self, player_id: str, action: dict) -> dict:
         state = await self._load_state()

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -211,6 +211,7 @@ async def _execute_action(game_id: str, player_id: str, action: dict) -> dict:
     if action_type == "roll":
         actor_name = _player_name(state, player_id)
         dice = result.get("dice")
+        reachable_targets = game.get_reachable_targets(player_id, state, dice)
         await manager.broadcast(
             game_id,
             {
@@ -218,6 +219,7 @@ async def _execute_action(game_id: str, player_id: str, action: dict) -> dict:
                 "player_id": player_id,
                 "dice": dice,
                 "last_roll": state.last_roll,
+                "reachable_rooms": reachable_targets["reachable_rooms"],
             },
         )
         await _broadcast_chat(
@@ -231,6 +233,8 @@ async def _execute_action(game_id: str, player_id: str, action: dict) -> dict:
             {
                 "type": "your_turn",
                 "available_actions": game.get_available_actions(player_id, state),
+                "reachable_rooms": reachable_targets["reachable_rooms"],
+                "reachable_positions": reachable_targets["reachable_positions"],
             },
         )
 

--- a/frontend/src/App.vue
+++ b/frontend/src/App.vue
@@ -27,6 +27,8 @@
       :chat-messages="chatMessages"
       :is-observer="isObserver"
       :auto-end-timer="autoEndTimer"
+      :reachable-rooms="reachableRooms"
+      :reachable-positions="reachablePositions"
       @action="sendAction"
       @send-chat="sendChat"
       @dismiss-card-shown="cardShown = null"
@@ -51,6 +53,8 @@ const chatMessages = ref([])
 const isObserver = ref(false)
 const urlGameId = ref(null)
 const autoEndTimer = ref(null)
+const reachableRooms = ref([])
+const reachablePositions = ref([])
 
 const gameStatus = computed(() => gameState.value?.status ?? 'waiting')
 const players = computed(() => gameState.value?.players ?? [])
@@ -150,6 +154,8 @@ function handleMessage(msg) {
         gameState.value = { ...gameState.value, ...fields }
       }
       autoEndTimer.value = null
+      reachableRooms.value = []
+      reachablePositions.value = []
       break
 
     case 'player_joined':
@@ -172,6 +178,8 @@ function handleMessage(msg) {
 
     case 'your_turn':
       if (msg.available_actions) availableActions.value = msg.available_actions
+      if (msg.reachable_rooms) reachableRooms.value = msg.reachable_rooms
+      if (msg.reachable_positions) reachablePositions.value = msg.reachable_positions
       showCardRequest.value = null
       autoEndTimer.value = null
       break
@@ -194,6 +202,7 @@ function handleMessage(msg) {
       if (gameState.value) {
         gameState.value = { ...gameState.value, last_roll: msg.last_roll, dice_rolled: true }
       }
+      if (msg.reachable_rooms) reachableRooms.value = msg.reachable_rooms
       break
 
     case 'player_moved':
@@ -205,6 +214,9 @@ function handleMessage(msg) {
         if (msg.dice) updates.last_roll = [msg.dice]
         gameState.value = { ...gameState.value, ...updates }
       }
+      // Clear reachable highlights after movement
+      reachableRooms.value = []
+      reachablePositions.value = []
       break
 
     case 'suggestion_made':
@@ -283,6 +295,8 @@ function resetState() {
   chatMessages.value = []
   isObserver.value = false
   autoEndTimer.value = null
+  reachableRooms.value = []
+  reachablePositions.value = []
 }
 
 function leaveGame() {

--- a/frontend/src/components/BoardMap.vue
+++ b/frontend/src/components/BoardMap.vue
@@ -178,6 +178,8 @@ const props = defineProps({
   playerId: String,
   selectedRoom: String,
   selectable: Boolean,
+  reachableRooms: { type: Array, default: () => [] },
+  reachablePositions: { type: Array, default: () => [] },
 })
 
 const emit = defineEmits(['select-room', 'select-position'])
@@ -185,6 +187,16 @@ const emit = defineEmits(['select-room', 'select-position'])
 const cells = CELL_DATA
 
 const currentRoom = computed(() => props.gameState?.current_room?.[props.playerId] ?? null)
+
+const reachablePositionSet = computed(() => {
+  const set = new Set()
+  for (const pos of props.reachablePositions) {
+    set.add(`${pos[0]},${pos[1]}`)
+  }
+  return set
+})
+
+const hasReachableData = computed(() => props.reachableRooms.length > 0 || props.reachablePositions.length > 0)
 
 const roomLabels = computed(() => Object.values(ROOM_INFO))
 
@@ -247,8 +259,28 @@ function cellClasses(cell) {
     if (props.selectable) cls.push('clickable')
     if (props.selectedRoom === cell.room) cls.push('selected')
     if (currentRoom.value === cell.room) cls.push('my-room')
+    // Highlight reachable/unreachable rooms when selectable
+    if (props.selectable && hasReachableData.value) {
+      if (props.reachableRooms.includes(cell.room)) {
+        cls.push('reachable')
+      } else {
+        cls.push('unreachable')
+      }
+    }
   } else if ((cell.type === 'hallway' || cell.type === 'start') && props.selectable) {
     cls.push('clickable')
+    // Highlight reachable hallway positions
+    if (hasReachableData.value) {
+      const key = `${cell.row},${cell.col}`
+      if (reachablePositionSet.value.has(key)) {
+        cls.push('reachable')
+      }
+    }
+  } else if (cell.type === 'door' && props.selectable && hasReachableData.value) {
+    // Highlight doors of reachable rooms
+    if (props.reachableRooms.includes(cell.room)) {
+      cls.push('reachable-door')
+    }
   }
   return cls
 }
@@ -385,6 +417,39 @@ function tokenStyle(token) {
 
 .cell.my-room {
   box-shadow: inset 0 0 0 1px rgba(241, 196, 15, 0.3);
+}
+
+/* ── Reachable highlights ── */
+.cell.reachable {
+  outline: 1px solid rgba(46, 204, 113, 0.6);
+  z-index: 1;
+  animation: reachable-glow 2s ease-in-out infinite;
+}
+
+.cell-room.reachable {
+  filter: brightness(1.3);
+}
+
+.cell-hallway.reachable,
+.cell-start.reachable {
+  background: #3a4a4e;
+}
+
+.cell.unreachable {
+  filter: brightness(0.5);
+  opacity: 0.6;
+}
+
+.cell.reachable-door {
+  filter: brightness(1.6);
+  outline: 1px solid rgba(46, 204, 113, 0.8);
+  z-index: 2;
+  animation: reachable-glow 2s ease-in-out infinite;
+}
+
+@keyframes reachable-glow {
+  0%, 100% { box-shadow: inset 0 0 0 0 rgba(46, 204, 113, 0); }
+  50% { box-shadow: inset 0 0 4px 1px rgba(46, 204, 113, 0.3); }
 }
 
 /* ── Overlay ── */

--- a/frontend/src/components/GameBoard.vue
+++ b/frontend/src/components/GameBoard.vue
@@ -38,6 +38,8 @@
           :player-id="playerId"
           :selected-room="targetRoom"
           :selectable="canMove"
+          :reachable-rooms="reachableRooms"
+          :reachable-positions="reachablePositions"
           @select-room="onRoomSelected"
           @select-position="onPositionSelected"
         />
@@ -136,10 +138,15 @@
           <!-- Move (choose room after rolling) -->
           <div v-if="canMove" class="action-group">
             <h3>Move (rolled {{ gameState?.last_roll?.[0] }})</h3>
-            <p class="action-hint">Click a room on the board or select below:</p>
+            <p class="action-hint">
+              Click a highlighted room on the board or select below:
+              <span v-if="reachableRooms.length" class="reachable-count">{{ reachableRooms.length }} room{{ reachableRooms.length !== 1 ? 's' : '' }} reachable</span>
+            </p>
             <select v-model="targetRoom" class="action-select">
               <option value="">-- Choose a room --</option>
-              <option v-for="room in ROOMS" :key="room" :value="room">{{ room }}</option>
+              <option v-for="room in ROOMS" :key="room" :value="room" :class="{ 'reachable-option': reachableRooms.includes(room) }">
+                {{ room }}{{ reachableRooms.includes(room) ? ' ✓' : '' }}
+              </option>
             </select>
             <button class="action-btn move-btn" :disabled="!targetRoom" @click="doMove">
               Move{{ targetRoom ? ' to ' + targetRoom : '' }}
@@ -273,6 +280,8 @@ const props = defineProps({
   chatMessages: { type: Array, default: () => [] },
   isObserver: { type: Boolean, default: false },
   autoEndTimer: { type: Object, default: null },
+  reachableRooms: { type: Array, default: () => [] },
+  reachablePositions: { type: Array, default: () => [] },
 })
 
 const emit = defineEmits(['action', 'send-chat', 'dismiss-card-shown'])
@@ -853,6 +862,13 @@ watch(
   font-size: 0.75rem;
   color: #667;
   margin-bottom: 0.3rem;
+}
+
+.reachable-count {
+  display: inline-block;
+  color: #2ecc71;
+  font-weight: bold;
+  margin-left: 0.3rem;
 }
 
 .action-select {


### PR DESCRIPTION
## Summary
This PR adds visual highlighting of reachable rooms and hallway positions based on the current dice roll during the movement phase. Players can now see which destinations are actually reachable before selecting their move.

## Key Changes

**Backend (game.py & main.py):**
- Added `get_reachable_targets()` method to compute reachable rooms and hallway positions for a given dice roll
- Integrated reachability calculation into the dice roll and turn flow
- Broadcasts reachable targets to the active player via `your_turn` and `dice_rolled` messages

**Frontend (App.vue):**
- Added `reachableRooms` and `reachablePositions` reactive state
- Populated these from incoming WebSocket messages (`your_turn` and `dice_rolled`)
- Clear highlights after movement completes

**Frontend (GameBoard.vue):**
- Pass reachable data to BoardMap component
- Updated move action UI to show count of reachable rooms
- Enhanced room dropdown to visually indicate reachable options with checkmarks

**Frontend (BoardMap.vue):**
- Added props for `reachableRooms` and `reachablePositions`
- Implemented `cellClasses()` logic to apply styling based on reachability:
  - Reachable rooms: brightened with green outline and glow animation
  - Unreachable rooms: dimmed and desaturated
  - Reachable hallway/start positions: highlighted with darker background
  - Reachable doors: brightened with enhanced outline
- Added CSS animations for subtle pulsing glow effect on reachable targets

## Implementation Details
- Reachability is computed server-side using the existing `reachable()` graph traversal function
- Hallway positions are tracked as `[row, col]` coordinates and matched against cell positions
- Visual feedback uses a combination of brightness filters, outlines, and animations for clear distinction
- Highlights are automatically cleared when movement completes or a new turn begins

https://claude.ai/code/session_014J6b3FuVKT7UbF6K5hB9p3