### PR TITLE
Run agents as a separate non-daemon process

### DIFF
--- a/backend/agent_runner.py
+++ b/backend/agent_runner.py
@@ -1,0 +1,374 @@
+"""Standalone agent runner process.
+
+Runs as a separate process from the FastAPI/uvicorn backend, so uvicorn
+reloads (dev mode) and pod restarts (k8s) don't kill running agents.
+
+Discovery:
+  - Polls Redis for ``game:{id}:agent_config`` keys written by the backend
+    when a game with agent players starts.
+
+Actions:
+  - Sends actions via the backend HTTP API (POST /games/{game_id}/action)
+    so the backend handles WebSocket broadcasting.
+
+Observations:
+  - Reads observation events from ``game:{id}:agent_events`` (Redis list)
+    published by the backend after every action.
+"""
+
+import asyncio
+import json
+import logging
+import os
+import sys
+
+import httpx
+import redis.asyncio as aioredis
+
+# Ensure the backend package is importable
+sys.path.insert(0, os.path.dirname(__file__))
+
+from app.agents import BaseAgent, LLMAgent, RandomAgent, WandererAgent
+from app.game import ClueGame
+from app.logging import get_logging_config
+from app.models import GameState
+
+logger = logging.getLogger(__name__)
+
+BACKEND_URL = os.getenv("BACKEND_URL", "http://localhost:8000")
+REDIS_URL = os.getenv("REDIS_URL", "redis://localhost:6379")
+POLL_INTERVAL = float(os.getenv("AGENT_POLL_INTERVAL", "2"))
+
+
+def _player_name(state: GameState, player_id: str) -> str:
+    for p in state.players:
+        if p.id == player_id:
+            return p.name
+    return player_id
+
+
+class AgentRunner:
+    """Manages agent players across all active games."""
+
+    def __init__(self):
+        self.redis: aioredis.Redis | None = None
+        self.http: httpx.AsyncClient | None = None
+        self.managed_games: dict[str, asyncio.Task] = {}
+
+    async def start(self):
+        self.redis = aioredis.from_url(REDIS_URL, decode_responses=True)
+        self.http = httpx.AsyncClient(base_url=BACKEND_URL, timeout=30)
+        logger.info(
+            "Agent runner started (backend=%s, redis=%s)", BACKEND_URL, REDIS_URL
+        )
+
+        try:
+            while True:
+                await self._discover_games()
+                # Clean up finished game tasks
+                finished = [
+                    gid for gid, task in self.managed_games.items() if task.done()
+                ]
+                for gid in finished:
+                    task = self.managed_games.pop(gid)
+                    # Log any exception that wasn't handled
+                    if task.exception():
+                        logger.error(
+                            "Game %s agent task failed: %s", gid, task.exception()
+                        )
+                await asyncio.sleep(POLL_INTERVAL)
+        finally:
+            for task in self.managed_games.values():
+                task.cancel()
+            if self.http:
+                await self.http.aclose()
+            if self.redis:
+                await self.redis.aclose()
+
+    async def _discover_games(self):
+        """Scan Redis for games that need agent management."""
+        async for key in self.redis.scan_iter("game:*:agent_config"):
+            game_id = key.split(":")[1]
+            if game_id in self.managed_games:
+                continue
+
+            config_raw = await self.redis.get(key)
+            if not config_raw:
+                continue
+
+            config = json.loads(config_raw)
+
+            # Check if game is still active
+            game = ClueGame(game_id, self.redis)
+            state = await game.get_state()
+            if not state or state.status != "playing":
+                # Game is over or doesn't exist — clean up config
+                await self.redis.delete(key)
+                continue
+
+            logger.info(
+                "Discovered game %s with %d agent(s)", game_id, len(config)
+            )
+            task = asyncio.create_task(self._run_game(game_id, config))
+            self.managed_games[game_id] = task
+
+    async def _run_game(self, game_id: str, config: dict):
+        """Manage agents for a single game."""
+        agents: dict[str, BaseAgent] = {}
+        event_cursor = 0
+
+        for pid, info in config.items():
+            ptype = info["type"]
+            if ptype == "llm_agent":
+                agent: BaseAgent = LLMAgent()
+            elif ptype == "wanderer":
+                agent = WandererAgent()
+            else:
+                agent = RandomAgent()
+
+            agent.character = info["character"]
+            agent.player_id = pid
+            agent.observe_own_cards(info["cards"])
+            agents[pid] = agent
+            logger.info(
+                "Created %s agent for %s (%s) in game %s",
+                ptype,
+                pid,
+                info["character"],
+                game_id,
+            )
+
+        try:
+            await self._agent_loop(game_id, agents, event_cursor)
+        except asyncio.CancelledError:
+            logger.info("Agent loop cancelled for game %s", game_id)
+        except Exception:
+            logger.exception("Agent loop error in game %s", game_id)
+        finally:
+            await self.redis.delete(f"game:{game_id}:agent_config")
+            logger.info("Agent loop ended for game %s", game_id)
+
+    # ------------------------------------------------------------------
+    # Observation events
+    # ------------------------------------------------------------------
+
+    async def _consume_events(
+        self, game_id: str, agents: dict[str, BaseAgent], cursor: int
+    ) -> int:
+        """Read new observation events from Redis and update agents.
+
+        Returns the updated cursor position.
+        """
+        key = f"game:{game_id}:agent_events"
+        events = await self.redis.lrange(key, cursor, -1)
+        for event_raw in events:
+            event = json.loads(event_raw)
+            self._apply_event(agents, event)
+        return cursor + len(events)
+
+    @staticmethod
+    def _apply_event(agents: dict[str, BaseAgent], event: dict):
+        """Apply an observation event to all relevant agents."""
+        etype = event.get("type")
+
+        if etype == "show_card":
+            shown_by = event["shown_by"]
+            shown_to = event["shown_to"]
+            card = event["card"]
+            suspect = event.get("suspect", "")
+            weapon = event.get("weapon", "")
+            room = event.get("room", "")
+
+            # The suggesting player learns which card was shown
+            if shown_to in agents and card:
+                agents[shown_to].observe_shown_card(card, shown_by=shown_by)
+
+            # Other agents note that a card was shown (for inference)
+            for aid, agent in agents.items():
+                if aid not in (shown_to, shown_by) and suspect and weapon and room:
+                    agent.observe_card_shown_to_other(
+                        shown_by=shown_by,
+                        shown_to=shown_to,
+                        suspect=suspect,
+                        weapon=weapon,
+                        room=room,
+                    )
+
+        elif etype == "suggest":
+            suggesting_pid = event["suggesting_player_id"]
+            shown_by = event.get("shown_by")
+            players_without = event.get("players_without_match", [])
+
+            for _aid, agent in agents.items():
+                agent.observe_suggestion(
+                    suggesting_player_id=suggesting_pid,
+                    suspect=event["suspect"],
+                    weapon=event["weapon"],
+                    room=event["room"],
+                    shown_by=shown_by,
+                    players_without_match=players_without,
+                )
+
+            # If no one could show a card, the suggesting agent also notes this
+            if shown_by is None and suggesting_pid in agents:
+                agents[suggesting_pid].observe_suggestion_no_show(
+                    event["suspect"],
+                    event["weapon"],
+                    event["room"],
+                )
+
+    # ------------------------------------------------------------------
+    # HTTP helpers
+    # ------------------------------------------------------------------
+
+    async def _send_action(
+        self, game_id: str, player_id: str, action: dict
+    ) -> dict:
+        """Send an action to the backend via the HTTP API."""
+        resp = await self.http.post(
+            f"/games/{game_id}/action",
+            json={"player_id": player_id, "action": action},
+        )
+        resp.raise_for_status()
+        return resp.json()
+
+    async def _send_chat(self, game_id: str, player_id: str, text: str):
+        """Send a chat message via the HTTP API."""
+        try:
+            await self.http.post(
+                f"/games/{game_id}/chat",
+                json={"player_id": player_id, "text": text},
+            )
+        except Exception:
+            logger.debug(
+                "Failed to send chat for %s in game %s", player_id, game_id
+            )
+
+    # ------------------------------------------------------------------
+    # Main agent loop
+    # ------------------------------------------------------------------
+
+    async def _agent_loop(
+        self,
+        game_id: str,
+        agents: dict[str, BaseAgent],
+        event_cursor: int,
+    ):
+        """Drive agent players — mirrors _run_agent_loop but uses HTTP."""
+        logger.info(
+            "Agent loop started for game %s with %d agent(s)",
+            game_id,
+            len(agents),
+        )
+
+        while True:
+            # Consume any pending observation events
+            event_cursor = await self._consume_events(
+                game_id, agents, event_cursor
+            )
+
+            game = ClueGame(game_id, self.redis)
+            state = await game.get_state()
+            if state is None or state.status != "playing":
+                break
+
+            pending = state.pending_show_card
+            if pending and pending.player_id in agents:
+                # An agent needs to show a card
+                await asyncio.sleep(1)
+                event_cursor = await self._consume_events(
+                    game_id, agents, event_cursor
+                )
+                state = await game.get_state()
+                if not state or state.status != "playing":
+                    break
+                pending = state.pending_show_card
+                if not pending or pending.player_id not in agents:
+                    continue
+
+                pid = pending.player_id
+                agent = agents[pid]
+                card = await agent.decide_show_card(
+                    pending.matching_cards, pending.suggesting_player_id
+                )
+
+                logger.info("Agent %s showing card in game %s", pid, game_id)
+                await self._send_action(
+                    game_id, pid, {"type": "show_card", "card": card}
+                )
+                # Broadcast personality chat
+                chat_msg = agent.generate_chat("show_card")
+                if chat_msg:
+                    s = await game.get_state()
+                    name = _player_name(s, pid) if s else pid
+                    await self._send_chat(
+                        game_id, pid, f"{name}: {chat_msg}"
+                    )
+
+            elif pending:
+                # A human player must show a card — wait
+                await asyncio.sleep(0.5)
+
+            elif state.whose_turn in agents:
+                # It's an agent's turn
+                agent = agents[state.whose_turn]
+                if agent.agent_type != "llm":
+                    await asyncio.sleep(1.35)
+
+                # Re-check state
+                event_cursor = await self._consume_events(
+                    game_id, agents, event_cursor
+                )
+                state = await game.get_state()
+                if not state or state.status != "playing":
+                    break
+                pid = state.whose_turn
+                if pid not in agents:
+                    continue
+
+                agent = agents[pid]
+                player_state = await game.get_player_state(pid)
+                action = await agent.decide_action(state, player_state)
+
+                logger.info(
+                    "Agent %s taking action %s in game %s",
+                    pid,
+                    action.get("type"),
+                    game_id,
+                )
+                result = await self._send_action(game_id, pid, action)
+
+                # Broadcast personality chat after the action
+                chat_context = {
+                    "dice": result.get("dice", ""),
+                    "room": result.get("room") or action.get("room") or "",
+                    "suspect": action.get("suspect", ""),
+                    "weapon": action.get("weapon", ""),
+                }
+                chat_msg = agent.generate_chat(
+                    action.get("type", ""), chat_context
+                )
+                if chat_msg:
+                    s = await game.get_state()
+                    name = _player_name(s, pid) if s else pid
+                    await self._send_chat(
+                        game_id, pid, f"{name}: {chat_msg}"
+                    )
+
+            else:
+                # Human player's turn — poll periodically
+                await asyncio.sleep(0.5)
+
+
+async def main():
+    runner = AgentRunner()
+    await runner.start()
+
+
+if __name__ == "__main__":
+    import logging.config
+
+    log_level = os.getenv("LOG_LEVEL", "INFO").upper()
+    log_format = os.getenv("LOG_FORMAT", "colored")
+    logging.config.dictConfig(get_logging_config(log_level=log_level, log_format=log_format))
+    asyncio.run(main())

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -84,6 +84,9 @@ AUTO_END_TURN_SECONDS = 15
 # Player types that trigger the automated agent loop
 _AGENT_PLAYER_TYPES = {"agent", "llm_agent", "wanderer"}
 
+# Agent mode: "inline" runs agents in-process (legacy), "external" relies on agent_runner
+_AGENT_MODE = os.getenv("AGENT_MODE", "inline")
+
 
 def _new_id(length: int = 6) -> str:
     return "".join(random.choices(string.ascii_uppercase + string.digits, k=length))
@@ -452,6 +455,9 @@ async def _execute_action(game_id: str, player_id: str, action: dict) -> dict:
     # Update agent observations for any active agents in this game
     _update_agent_observations(game_id, player_id, action, result)
 
+    # Publish observation events to Redis for external agent runners
+    await _publish_agent_event(game_id, player_id, action, result)
+
     # Check if the current player should get an auto-end-turn timer
     await _maybe_start_auto_end_timer(game_id)
 
@@ -513,6 +519,48 @@ def _update_agent_observations(
                 action["weapon"],
                 action["room"],
             )
+
+
+# ---------------------------------------------------------------------------
+# Agent observation events (Redis-backed for external agent runner)
+# ---------------------------------------------------------------------------
+
+
+async def _publish_agent_event(
+    game_id: str, player_id: str, action: dict, result: dict
+):
+    """Publish observation events to Redis for external agent runners."""
+    if not redis_client:
+        return
+
+    action_type = action.get("type")
+    event = None
+
+    if action_type == "show_card":
+        event = {
+            "type": "show_card",
+            "shown_by": player_id,
+            "shown_to": result.get("suggesting_player_id"),
+            "card": result.get("card"),
+            "suspect": result.get("suspect", ""),
+            "weapon": result.get("weapon", ""),
+            "room": result.get("room", ""),
+        }
+    elif action_type == "suggest":
+        event = {
+            "type": "suggest",
+            "suggesting_player_id": player_id,
+            "suspect": action["suspect"],
+            "weapon": action["weapon"],
+            "room": action["room"],
+            "shown_by": result.get("pending_show_by"),
+            "players_without_match": result.get("players_without_match", []),
+        }
+
+    if event:
+        key = f"game:{game_id}:agent_events"
+        await redis_client.rpush(key, json.dumps(event))
+        await redis_client.expire(key, 86400)
 
 
 # ---------------------------------------------------------------------------
@@ -758,30 +806,55 @@ async def start_game(game_id: str):
     # Start background agent loop for any agent players (including wanderers)
     agent_players = [p for p in state.players if p.type in _AGENT_PLAYER_TYPES]
     if agent_players:
-        agents: dict[str, BaseAgent] = {}
+        # Always store agent config in Redis so external runners can pick it up
+        agent_config = {}
         for player in agent_players:
             pid = player.id
-            ptype = player.type
-            if ptype == "llm_agent":
-                agent: BaseAgent = LLMAgent()
-            elif ptype == "wanderer":
-                agent = WandererAgent()
-            else:
-                agent = RandomAgent()
-            agent.character = player.character
-            agent.player_id = pid
             cards = await game._load_player_cards(pid)
-            agent.observe_own_cards(cards)
-            agents[pid] = agent
+            agent_config[pid] = {
+                "type": player.type,
+                "character": player.character,
+                "cards": cards,
+            }
+        await redis_client.set(
+            f"game:{game_id}:agent_config",
+            json.dumps(agent_config),
+            ex=86400,
+        )
+
+        if _AGENT_MODE == "inline":
+            # Run agents in-process (original behavior)
+            agents: dict[str, BaseAgent] = {}
+            for player in agent_players:
+                pid = player.id
+                ptype = player.type
+                if ptype == "llm_agent":
+                    agent: BaseAgent = LLMAgent()
+                elif ptype == "wanderer":
+                    agent = WandererAgent()
+                else:
+                    agent = RandomAgent()
+                agent.character = player.character
+                agent.player_id = pid
+                cards = await game._load_player_cards(pid)
+                agent.observe_own_cards(cards)
+                agents[pid] = agent
+                logger.info(
+                    "Created %s agent for player %s (%s) in game %s",
+                    ptype,
+                    pid,
+                    player.character,
+                    game_id,
+                )
+            _game_agents[game_id] = agents
+            _agent_tasks[game_id] = asyncio.create_task(_run_agent_loop(game_id))
+        else:
             logger.info(
-                "Created %s agent for player %s (%s) in game %s",
-                ptype,
-                pid,
-                player.character,
+                "Agent mode is '%s' — %d agent(s) in game %s will be managed externally",
+                _AGENT_MODE,
+                len(agent_players),
                 game_id,
             )
-        _game_agents[game_id] = agents
-        _agent_tasks[game_id] = asyncio.create_task(_run_agent_loop(game_id))
 
     return state.model_dump()
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -16,6 +16,7 @@ services:
       - LLM_MODEL=${LLM_MODEL:-gpt-5-mini}
       - LLM_API_KEY=${LLM_API_KEY}
       - LLM_TRACE_LOG_LEVEL=${LLM_TRACE_LOG_LEVEL:-info}
+      - AGENT_MODE=external
     ports:
       - "8000:8000"
     volumes:
@@ -23,8 +24,29 @@ services:
     depends_on:
       - redis
 
+  agent-runner:
+    build:
+      context: .
+      dockerfile: backend/Dockerfile
+    command: python agent_runner.py
+    environment:
+      - REDIS_URL=redis://redis:6379
+      - BACKEND_URL=http://backend:8000
+      - LOG_LEVEL=${LOG_LEVEL:-debug}
+      - LOG_FORMAT=${LOG_FORMAT:-colored}
+      - LLM_MODEL=${LLM_MODEL:-gpt-5-mini}
+      - LLM_API_KEY=${LLM_API_KEY}
+      - LLM_TRACE_LOG_LEVEL=${LLM_TRACE_LOG_LEVEL:-info}
+      - AGENT_POLL_INTERVAL=2
+    volumes:
+      - ./backend:/app
+    depends_on:
+      - redis
+      - backend
+    restart: unless-stopped
+
   frontend:
-    build: 
+    build:
       context: ./frontend
     working_dir: /app
     command: npm run dev -- --host

--- a/k8s/agent-runner.yaml
+++ b/k8s/agent-runner.yaml
@@ -1,0 +1,44 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: agent-runner
+  namespace: clue
+  labels:
+    app: agent-runner
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: agent-runner
+  template:
+    metadata:
+      labels:
+        app: agent-runner
+    spec:
+      containers:
+        - name: agent-runner
+          # Same image as the backend — just a different entrypoint
+          image: clue-backend:latest
+          command: ["python", "agent_runner.py"]
+          env:
+            - name: REDIS_URL
+              value: redis://redis:6379
+            - name: BACKEND_URL
+              value: http://backend:8000
+            - name: AGENT_POLL_INTERVAL
+              value: "2"
+            - name: LLM_API_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: clue-secrets
+                  key: llm-api-key
+                  optional: true
+            - name: LLM_MODEL
+              value: "gpt-5-mini"
+          resources:
+            requests:
+              memory: "128Mi"
+              cpu: "100m"
+            limits:
+              memory: "256Mi"
+              cpu: "500m"

--- a/k8s/backend.yaml
+++ b/k8s/backend.yaml
@@ -24,6 +24,8 @@ spec:
           env:
             - name: REDIS_URL
               value: redis://redis:6379
+            - name: AGENT_MODE
+              value: external
             # Set CORS_ORIGINS to restrict allowed origins in production,
             # e.g. "https://yourdomain.com". Defaults to "*" if unset.
             # - name: CORS_ORIGINS


### PR DESCRIPTION
Agents previously ran as asyncio tasks inside the uvicorn process, so dev reloads and pod restarts would kill active agent loops mid-game.

- Add AGENT_MODE env var ("inline" default, "external" for separate process)
- Backend publishes observation events to Redis (game:{id}:agent_events) and stores agent config (game:{id}:agent_config) when games start
- New backend/agent_runner.py: standalone process that discovers games via Redis, runs agent decision loops, and sends actions via HTTP API
- docker-compose: add agent-runner service with AGENT_MODE=external
- k8s: add agent-runner.yaml Deployment, set AGENT_MODE=external on backend

https://claude.ai/code/session_01RtWXR4sBPyVMAJeTx2cLLu