### PR TITLE
Allow free suggestion when player moved into room by suggestion

### DIFF
--- a/backend/app/game.py
+++ b/backend/app/game.py
@@ -202,6 +202,13 @@ class ClueGame:
             if current_room and current_room in SECRET_PASSAGE_MAP:
                 actions.append("secret_passage")
             actions.append("roll")
+            # If pulled into a room by a suggestion, can suggest without rolling
+            if (
+                current_room
+                and not suggestions_made
+                and state.was_moved_by_suggestion.get(player_id)
+            ):
+                actions.append("suggest")
         elif state.dice_rolled and not state.moved:
             # Phase 2: dice rolled, choose room to move toward
             actions.append("move")
@@ -605,6 +612,9 @@ class ClueGame:
                 center = ROOM_CENTERS.get(room)
                 if center:
                     state.player_positions[moved_suspect_player] = list(center)
+                # Mark that this player was pulled into a room by a suggestion,
+                # so they can suggest from it on their next turn without rolling.
+                state.was_moved_by_suggestion[moved_suspect_player] = True
                 break
 
         suggestion_entry = Suggestion(
@@ -773,6 +783,7 @@ class ClueGame:
         state.moved = False
         state.last_roll = None
         state.suggestions_this_turn = []
+        state.was_moved_by_suggestion.pop(player_id, None)
         await self._save_state(state)
 
         await self._append_log(

--- a/backend/app/models.py
+++ b/backend/app/models.py
@@ -52,6 +52,7 @@ class GameState(BaseModel):
     moved: bool = False
     last_roll: Optional[list[int]] = None
     pending_show_card: Optional[PendingShowCard] = None
+    was_moved_by_suggestion: dict[str, bool] = Field(default_factory=dict)
 
 
 class PlayerState(GameState):

--- a/backend/tests/test_game.py
+++ b/backend/tests/test_game.py
@@ -699,6 +699,188 @@ async def test_secret_passage_all_pairs(game: ClueGame):
 
 
 # ---------------------------------------------------------------------------
+# Pawn moved by suggestion — free suggest on next turn
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_suggest_available_without_roll_after_moved_by_suggestion(game: ClueGame):
+    """A player moved into a room by a suggestion can suggest without rolling."""
+    await _add_two_players(game)
+    state = await game.start()
+
+    whose_turn = state.whose_turn
+    other_id = "P2" if whose_turn == "P1" else "P1"
+
+    # Find the other player's character
+    other_char = next(p.character for p in state.players if p.id == other_id)
+
+    room = ROOMS[0]
+    await _place_player_in_room(game, whose_turn, room)
+
+    # Make a suggestion naming the other player's character to pull them into the room
+    result = await game.process_action(
+        whose_turn,
+        {"type": "suggest", "suspect": other_char, "weapon": WEAPONS[0], "room": room},
+    )
+
+    # Resolve show_card if pending
+    if result.get("pending_show_by"):
+        st = await game._load_state()
+        matching = st.pending_show_card.matching_cards
+        await game.process_action(
+            result["pending_show_by"], {"type": "show_card", "card": matching[0]}
+        )
+
+    # End the current player's turn
+    await game.process_action(whose_turn, {"type": "end_turn"})
+
+    # Now it's other_id's turn — they were moved by suggestion
+    state = await game.get_state()
+    # Skip wanderers to find the actual next human turn
+    while state.whose_turn != other_id:
+        # Advance past wanderer turns
+        wt = state.whose_turn
+        await game.process_action(wt, {"type": "roll"})
+        await game.process_action(wt, {"type": "end_turn"})
+        state = await game.get_state()
+
+    assert state.whose_turn == other_id
+    assert state.was_moved_by_suggestion.get(other_id) is True
+    assert state.current_room.get(other_id) == room
+
+    actions = game.get_available_actions(other_id, state)
+    assert "suggest" in actions
+    assert "roll" in actions  # can still choose to roll instead
+
+
+@pytest.mark.asyncio
+async def test_free_suggest_then_end_turn(game: ClueGame):
+    """A player pulled into a room can suggest and then end their turn."""
+    await _add_two_players(game)
+    state = await game.start()
+
+    whose_turn = state.whose_turn
+    other_id = "P2" if whose_turn == "P1" else "P1"
+    other_char = next(p.character for p in state.players if p.id == other_id)
+
+    room = ROOMS[0]
+    await _place_player_in_room(game, whose_turn, room)
+
+    result = await game.process_action(
+        whose_turn,
+        {"type": "suggest", "suspect": other_char, "weapon": WEAPONS[0], "room": room},
+    )
+    if result.get("pending_show_by"):
+        st = await game._load_state()
+        matching = st.pending_show_card.matching_cards
+        await game.process_action(
+            result["pending_show_by"], {"type": "show_card", "card": matching[0]}
+        )
+
+    await game.process_action(whose_turn, {"type": "end_turn"})
+
+    # Advance to other_id's turn
+    state = await game.get_state()
+    while state.whose_turn != other_id:
+        wt = state.whose_turn
+        await game.process_action(wt, {"type": "roll"})
+        await game.process_action(wt, {"type": "end_turn"})
+        state = await game.get_state()
+
+    # Use the free suggest
+    result = await game.process_action(
+        other_id,
+        {"type": "suggest", "suspect": SUSPECTS[0], "weapon": WEAPONS[0], "room": room},
+    )
+    assert result["type"] == "suggest"
+
+    # Resolve show_card if pending
+    if result.get("pending_show_by"):
+        st = await game._load_state()
+        matching = st.pending_show_card.matching_cards
+        await game.process_action(
+            result["pending_show_by"], {"type": "show_card", "card": matching[0]}
+        )
+
+    # Should be able to end turn now
+    state = await game.get_state()
+    actions = game.get_available_actions(other_id, state)
+    assert "end_turn" in actions
+    assert "suggest" not in actions  # already suggested this turn
+
+    await game.process_action(other_id, {"type": "end_turn"})
+
+
+@pytest.mark.asyncio
+async def test_flag_cleared_after_turn_ends(game: ClueGame):
+    """The was_moved_by_suggestion flag is cleared when the player ends their turn."""
+    await _add_two_players(game)
+    state = await game.start()
+
+    whose_turn = state.whose_turn
+    other_id = "P2" if whose_turn == "P1" else "P1"
+    other_char = next(p.character for p in state.players if p.id == other_id)
+
+    room = ROOMS[0]
+    await _place_player_in_room(game, whose_turn, room)
+
+    result = await game.process_action(
+        whose_turn,
+        {"type": "suggest", "suspect": other_char, "weapon": WEAPONS[0], "room": room},
+    )
+    if result.get("pending_show_by"):
+        st = await game._load_state()
+        matching = st.pending_show_card.matching_cards
+        await game.process_action(
+            result["pending_show_by"], {"type": "show_card", "card": matching[0]}
+        )
+
+    await game.process_action(whose_turn, {"type": "end_turn"})
+
+    # Advance to other_id's turn
+    state = await game.get_state()
+    while state.whose_turn != other_id:
+        wt = state.whose_turn
+        await game.process_action(wt, {"type": "roll"})
+        await game.process_action(wt, {"type": "end_turn"})
+        state = await game.get_state()
+
+    # Flag is set
+    assert state.was_moved_by_suggestion.get(other_id) is True
+
+    # Roll and end turn (choosing not to use free suggest)
+    await game.process_action(other_id, {"type": "roll"})
+    await game.process_action(other_id, {"type": "end_turn"})
+
+    # Flag should be cleared
+    state = await game.get_state()
+    assert state.was_moved_by_suggestion.get(other_id) is None
+
+
+@pytest.mark.asyncio
+async def test_no_free_suggest_without_being_moved(game: ClueGame):
+    """A player NOT moved by suggestion should not get suggest before rolling."""
+    await _add_two_players(game)
+    state = await game.start()
+
+    whose_turn = state.whose_turn
+
+    # Place player in a room but without the suggestion flag
+    st = await game._load_state()
+    st.current_room[whose_turn] = ROOMS[0]
+    center = ROOM_CENTERS.get(ROOMS[0])
+    if center:
+        st.player_positions[whose_turn] = list(center)
+    await game._save_state(st)
+
+    state = await game.get_state()
+    actions = game.get_available_actions(whose_turn, state)
+    assert "suggest" not in actions  # no free suggest
+    assert "roll" in actions
+
+
+# ---------------------------------------------------------------------------
 # Memory tests
 # ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## Summary
Implements a game mechanic where a player who is moved into a room by another player's suggestion can make a suggestion on their next turn without needing to roll the dice first.

## Key Changes
- **GameState model**: Added `was_moved_by_suggestion` dictionary field to track which players were moved into rooms by suggestions
- **Suggestion handling**: When a player is moved into a room via suggestion, the `was_moved_by_suggestion` flag is set for that player
- **Available actions logic**: Modified `get_available_actions()` to allow "suggest" action when:
  - Player is in a room
  - Player hasn't made suggestions yet this turn
  - Player has the `was_moved_by_suggestion` flag set
- **Turn cleanup**: The `was_moved_by_suggestion` flag is cleared when the player ends their turn, regardless of whether they used the free suggestion

## Implementation Details
- The flag is set in `_handle_suggest()` when moving a suspect player into a room
- Players can still choose to roll instead of using the free suggestion
- The flag is automatically cleared via `state.was_moved_by_suggestion.pop(player_id, None)` in `_handle_end_turn()`
- Comprehensive test coverage includes: basic functionality, free suggest followed by end turn, flag clearing, and verification that non-moved players don't get the benefit

https://claude.ai/code/session_01R5P8kzmeVSNLct3U4wm3jz