### PR TITLE
Implement pawn collision detection and movement constraints

### DIFF
--- a/backend/app/board.py
+++ b/backend/app/board.py
@@ -330,13 +330,22 @@ def reachable(
     steps: int,
     squares: dict,
     room_nodes: dict[Room, Square],
+    occupied: set[tuple[int, int]] | None = None,
 ) -> dict[Square, int]:
     """
     BFS from `start` up to `steps` moves.
     Entering a room ends your turn (don't expand further from room node).
     Door <-> Room transitions are free (the door sits on the room perimeter).
     Uses 0-1 BFS: 0-cost edges go to the front of the deque.
+
+    occupied: set of (row, col) positions occupied by other pawns.
+        Hallway/door/start squares in this set are impassable (cannot be
+        entered or passed through).  Room nodes are never blocked — rooms
+        have infinite capacity.
     """
+    if occupied is None:
+        occupied = set()
+
     visited: dict[Square, int] = {start: 0}
     queue: deque[tuple[Square, int]] = deque([(start, 0)])
 
@@ -344,6 +353,11 @@ def reachable(
         sq, dist = queue.popleft()
 
         for nb in sq.neighbors:
+            # Hallway/door/start squares occupied by other pawns are
+            # impassable — cannot land on or pass through.
+            if nb.type != SquareType.ROOM and (nb.row, nb.col) in occupied:
+                continue
+
             # Door <-> Room transitions are free: the door square sits on
             # the room perimeter and shouldn't count as an extra step.
             if (sq.type == SquareType.ROOM and nb.type == SquareType.DOOR) or (
@@ -477,6 +491,7 @@ def move_towards(
     dice: int,
     squares: dict,
     room_nodes: dict[Room, Square],
+    occupied: set[tuple[int, int]] | None = None,
 ) -> tuple[Square, bool]:
     """
     Given a current location, a target room, and a dice roll, attempt to move
@@ -485,22 +500,32 @@ def move_towards(
     Returns (destination, reached) where:
       - destination is the Square to move to
       - reached is True if the target room was entered with this dice roll
+
+    occupied: forwarded to reachable() and the reverse BFS so that
+        hallway squares blocked by other pawns are avoided.
     """
-    reachable_squares = reachable(start, dice, squares, room_nodes)
+    if occupied is None:
+        occupied = set()
+
+    reachable_squares = reachable(start, dice, squares, room_nodes, occupied)
     target_node = room_nodes[target_room]
 
     # If the target room is directly reachable, move there
     if target_node in reachable_squares:
         return (target_node, True)
 
-    # Otherwise do an unconstrained BFS from the target room to get distances
+    # Otherwise do a reverse BFS from the target room to get distances
     # from every square back to the target, then pick the reachable square with
     # the smallest distance.  Uses 0-1 BFS for free Door <-> Room edges.
+    # Occupied squares are also impassable in the reverse BFS so that the
+    # distance estimate accounts for blocked paths.
     dist_from_target: dict[Square, int] = {target_node: 0}
     bfs_queue: deque[tuple[Square, int]] = deque([(target_node, 0)])
     while bfs_queue:
         sq, dist = bfs_queue.popleft()
         for nb in sq.neighbors:
+            if nb.type != SquareType.ROOM and (nb.row, nb.col) in occupied:
+                continue
             if (sq.type == SquareType.ROOM and nb.type == SquareType.DOOR) or (
                 sq.type == SquareType.DOOR and nb.type == SquareType.ROOM
             ):

--- a/backend/app/game.py
+++ b/backend/app/game.py
@@ -331,6 +331,24 @@ class ClueGame:
     def roll_dice(self) -> int:
         return random.randint(1, 6)
 
+    @staticmethod
+    def _get_occupied_positions(
+        state: "GameState", exclude_player_id: str
+    ) -> set[tuple[int, int]]:
+        """Return hallway positions occupied by other pawns.
+
+        Only players who are NOT currently inside a room are counted —
+        rooms have infinite capacity.
+        """
+        occupied: set[tuple[int, int]] = set()
+        for pid, pos in state.player_positions.items():
+            if pid == exclude_player_id:
+                continue
+            # Only count players in the hallway (not in a room)
+            if pid not in state.current_room:
+                occupied.add((pos[0], pos[1]))
+        return occupied
+
     def get_reachable_targets(
         self, player_id: str, state: "GameState", dice: int
     ) -> dict:
@@ -339,6 +357,10 @@ class ClueGame:
         Returns a dict with:
           - reachable_rooms: list of room names the player can enter
           - reachable_positions: list of [row, col] hallway positions reachable
+
+        Applies movement constraints:
+          - Occupied hallway/door squares are impassable
+          - The player's current room is excluded (cannot re-enter same room)
         """
         current_room_name = state.current_room.get(player_id)
         pos = state.player_positions.get(player_id)
@@ -353,12 +375,13 @@ class ClueGame:
         if not start_sq:
             return {"reachable_rooms": list(ROOMS), "reachable_positions": []}
 
-        reached = reachable(start_sq, dice, _SQUARES, _ROOM_NODES)
+        occupied = self._get_occupied_positions(state, player_id)
+        reached = reachable(start_sq, dice, _SQUARES, _ROOM_NODES, occupied)
 
         rooms = []
         positions = []
         for sq, dist in reached.items():
-            if sq.type == SquareType.ROOM and sq.room:
+            if sq.type == SquareType.ROOM and sq.room and sq != start_sq:
                 rooms.append(sq.room.value)
             elif sq != start_sq and sq.type in (
                 SquareType.HALLWAY,
@@ -478,6 +501,13 @@ class ClueGame:
         if room and room not in ROOMS:
             raise ValueError(f"Invalid room: {room}")
 
+        # Cannot re-enter the room you are already in
+        current_room_name = state.current_room.get(player_id)
+        if room and room == current_room_name:
+            raise ValueError("Cannot re-enter the room you are already in")
+
+        occupied = self._get_occupied_positions(state, player_id)
+
         if target_pos and not room:
             # Position-based move: player clicked a specific hallway cell
             target_row, target_col = int(target_pos[0]), int(target_pos[1])
@@ -485,7 +515,6 @@ class ClueGame:
             if not target_sq:
                 raise ValueError("Invalid position")
 
-            current_room_name = state.current_room.get(player_id)
             pos = state.player_positions.get(player_id)
             if current_room_name and current_room_name in _ROOM_NAME_TO_ENUM:
                 start_sq = _ROOM_NODES[_ROOM_NAME_TO_ENUM[current_room_name]]
@@ -495,7 +524,9 @@ class ClueGame:
                 start_sq = None
 
             if start_sq:
-                reachable_squares = reachable(start_sq, total, _SQUARES, _ROOM_NODES)
+                reachable_squares = reachable(
+                    start_sq, total, _SQUARES, _ROOM_NODES, occupied
+                )
                 if target_sq in reachable_squares:
                     state.current_room.pop(player_id, None)
                     state.player_positions[player_id] = [target_row, target_col]
@@ -508,7 +539,6 @@ class ClueGame:
 
         elif room:
             # Determine the player's current position on the board graph
-            current_room_name = state.current_room.get(player_id)
             pos = state.player_positions.get(player_id)
 
             if current_room_name and current_room_name in _ROOM_NAME_TO_ENUM:
@@ -522,7 +552,8 @@ class ClueGame:
 
             if start_sq and target_room_enum:
                 dest, reached = move_towards(
-                    start_sq, target_room_enum, total, _SQUARES, _ROOM_NODES
+                    start_sq, target_room_enum, total, _SQUARES, _ROOM_NODES,
+                    occupied,
                 )
                 if reached:
                     # Player reaches the room
@@ -532,6 +563,10 @@ class ClueGame:
                     if center:
                         state.player_positions[player_id] = list(center)
                         result["position"] = list(center)
+                elif dest == start_sq:
+                    # Player couldn't actually move (all paths blocked)
+                    result["room"] = current_room_name
+                    result["position"] = state.player_positions.get(player_id)
                 else:
                     # Player ends up in the hallway partway there
                     result["room"] = None

--- a/backend/tests/test_board.py
+++ b/backend/tests/test_board.py
@@ -183,3 +183,89 @@ def test_move_towards_large_roll_reaches_room(board):
     dest, reached = move_towards(start, Room.BALLROOM, 1, squares, room_nodes)
     assert reached is True
     assert dest == room_nodes[Room.BALLROOM]
+
+
+# ---------------------------------------------------------------------------
+# Occupied-square / collision tests
+# ---------------------------------------------------------------------------
+
+
+def test_occupied_square_not_reachable(board):
+    """A hallway square occupied by another pawn cannot be landed on."""
+    squares, room_nodes = board
+    # (7,17) is a hallway square; (7,18) is adjacent
+    start = squares[(7, 17)]
+    occupied = {(7, 18)}
+
+    reached = reachable(start, 1, squares, room_nodes, occupied)
+    target = squares.get((7, 18))
+    assert target is not None
+    assert target not in reached
+
+
+def test_occupied_square_blocks_passage(board):
+    """An occupied hallway square blocks movement through it entirely."""
+    squares, room_nodes = board
+    start = squares[(7, 17)]
+
+    # Without obstacle, (7,19) is reachable in 2 steps via (7,18)
+    reached_free = reachable(start, 2, squares, room_nodes)
+    sq_19 = squares.get((7, 19))
+    assert sq_19 is not None
+    assert sq_19 in reached_free
+
+    # With (7,18) occupied, (7,19) can't be reached through that path
+    # (it may still be reachable via other routes)
+    reached_blocked = reachable(start, 2, squares, room_nodes, occupied={(7, 18)})
+    # At minimum, fewer squares are reachable
+    assert len(reached_blocked) <= len(reached_free)
+
+
+def test_door_blocked_traps_player_in_room(board):
+    """Blocking the only door of a room prevents hallway exit."""
+    squares, room_nodes = board
+    # Conservatory has exactly 1 door at (19, 4)
+    conservatory = room_nodes[Room.CONSERVATORY]
+
+    reached = reachable(conservatory, 6, squares, room_nodes, occupied={(19, 4)})
+
+    hallway_squares = [sq for sq in reached if sq.type != SquareType.ROOM]
+    assert len(hallway_squares) == 0, (
+        "Player should not reach any hallway squares when the only door is blocked"
+    )
+    # Secret passage to Lounge should still work
+    assert room_nodes[Room.LOUNGE] in reached
+
+
+def test_one_blocked_door_still_allows_exit(board):
+    """If only one of multiple doors is blocked, the other still works."""
+    squares, room_nodes = board
+    # Library has 2 doors: (8,6) and (10,3)
+    library = room_nodes[Room.LIBRARY]
+
+    reached = reachable(library, 6, squares, room_nodes, occupied={(8, 6)})
+
+    # Unblocked door (10,3) should still be reachable
+    door_sq = squares.get((10, 3))
+    assert door_sq in reached
+    hallway_squares = [sq for sq in reached if sq.type != SquareType.ROOM]
+    assert len(hallway_squares) > 0, (
+        "Player should reach hallway through the unblocked door"
+    )
+
+
+def test_room_has_infinite_capacity(board):
+    """Rooms are never blocked by occupants — rooms have infinite capacity."""
+    squares, room_nodes = board
+    ballroom = room_nodes[Room.BALLROOM]
+    # Even with the room center coords in the occupied set, the room is still
+    # reachable because room nodes are exempt from collision checks.
+    start = squares.get((17, 9))  # Ballroom door
+    if start is None:
+        pytest.skip("Door square not found")
+
+    reached = reachable(
+        start, 1, squares, room_nodes,
+        occupied={(ballroom.row, ballroom.col)},
+    )
+    assert ballroom in reached, "Room should be reachable regardless of occupants"

--- a/backend/tests/test_game.py
+++ b/backend/tests/test_game.py
@@ -727,3 +727,124 @@ async def test_memory_per_player(game):
 
     assert await game.get_memory("player1") == ["Note for player 1"]
     assert await game.get_memory("player2") == ["Note for player 2"]
+
+
+# ---------------------------------------------------------------------------
+# Pawn movement rules
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_cannot_reenter_same_room(game: ClueGame):
+    """A player cannot move to the room they are already in."""
+    await _add_two_players(game)
+    state = await game.start()
+    whose_turn = state.whose_turn
+
+    # Place player in Kitchen
+    st = await game._load_state()
+    st.current_room[whose_turn] = "Kitchen"
+    center = ROOM_CENTERS.get("Kitchen")
+    if center:
+        st.player_positions[whose_turn] = list(center)
+    await game._save_state(st)
+
+    # Roll dice
+    await game.process_action(whose_turn, {"type": "roll"})
+
+    # Try to move to Kitchen (the room they're already in)
+    with pytest.raises(ValueError, match="Cannot re-enter"):
+        await game.process_action(whose_turn, {"type": "move", "room": "Kitchen"})
+
+
+@pytest.mark.asyncio
+async def test_current_room_excluded_from_reachable(game: ClueGame):
+    """The player's current room should not appear in reachable_rooms."""
+    await _add_two_players(game)
+    state = await game.start()
+    whose_turn = state.whose_turn
+
+    # Place player in Study
+    st = await game._load_state()
+    st.current_room[whose_turn] = "Study"
+    center = ROOM_CENTERS.get("Study")
+    if center:
+        st.player_positions[whose_turn] = list(center)
+    await game._save_state(st)
+
+    state = await game._load_state()
+    targets = game.get_reachable_targets(whose_turn, state, 6)
+    assert "Study" not in targets["reachable_rooms"]
+
+
+@pytest.mark.asyncio
+async def test_occupied_hallway_blocks_movement(game: ClueGame):
+    """A hallway square occupied by another pawn cannot be moved to."""
+    await _add_two_players(game)
+    state = await game.start()
+    whose_turn = state.whose_turn
+    other_id = "P2" if whose_turn == "P1" else "P1"
+
+    # Place both players in adjacent hallway positions
+    st = await game._load_state()
+    st.player_positions[whose_turn] = [7, 17]
+    st.player_positions[other_id] = [7, 18]
+    st.current_room.pop(whose_turn, None)
+    st.current_room.pop(other_id, None)
+    await game._save_state(st)
+
+    state = await game._load_state()
+    targets = game.get_reachable_targets(whose_turn, state, 1)
+    # The occupied square (7, 18) must not be reachable
+    assert [7, 18] not in targets["reachable_positions"]
+
+
+@pytest.mark.asyncio
+async def test_door_blocking_prevents_exit(game: ClueGame):
+    """A pawn blocking the only door of a room traps players inside."""
+    await _add_two_players(game)
+    state = await game.start()
+    whose_turn = state.whose_turn
+    other_id = "P2" if whose_turn == "P1" else "P1"
+
+    # Place current player in Conservatory (1 door at (19,4))
+    # Place other player on that door square
+    st = await game._load_state()
+    st.current_room[whose_turn] = "Conservatory"
+    center = ROOM_CENTERS.get("Conservatory")
+    if center:
+        st.player_positions[whose_turn] = list(center)
+    st.player_positions[other_id] = [19, 4]
+    st.current_room.pop(other_id, None)
+    await game._save_state(st)
+
+    state = await game._load_state()
+    targets = game.get_reachable_targets(whose_turn, state, 6)
+    # No hallway positions reachable
+    assert len(targets["reachable_positions"]) == 0
+    # Secret passage to Lounge still works
+    assert "Lounge" in targets["reachable_rooms"]
+
+
+@pytest.mark.asyncio
+async def test_room_players_do_not_block(game: ClueGame):
+    """Players inside a room do not block hallway squares."""
+    await _add_two_players(game)
+    state = await game.start()
+    whose_turn = state.whose_turn
+    other_id = "P2" if whose_turn == "P1" else "P1"
+
+    # Both players in the same room — should not interfere
+    st = await game._load_state()
+    st.current_room[whose_turn] = "Kitchen"
+    st.current_room[other_id] = "Kitchen"
+    center = ROOM_CENTERS.get("Kitchen")
+    if center:
+        st.player_positions[whose_turn] = list(center)
+        st.player_positions[other_id] = list(center)
+    await game._save_state(st)
+
+    state = await game._load_state()
+    targets = game.get_reachable_targets(whose_turn, state, 6)
+    # Should still be able to reach hallway/rooms (door is not blocked)
+    assert len(targets["reachable_positions"]) > 0 or len(targets["reachable_rooms"]) > 0


### PR DESCRIPTION
## Summary
This PR adds collision detection and movement constraint logic to enforce realistic pawn movement rules in the Clue game. Players can no longer move through occupied hallway squares or re-enter their current room, and blocked doors can trap players inside rooms (unless secret passages are available).

## Key Changes

### Board Movement Logic (`backend/app/board.py`)
- **`reachable()` function**: Added `occupied` parameter to track hallway/door squares blocked by other pawns. Occupied squares are now impassable during BFS traversal, while room nodes remain unblocked (infinite capacity).
- **`move_towards()` function**: Added `occupied` parameter and integrated it into both forward and reverse BFS pathfinding. The reverse BFS now respects occupied squares when calculating distances to the target room, ensuring blocked paths are avoided.

### Game State Management (`backend/app/game.py`)
- **`_get_occupied_positions()` helper**: New static method that returns positions of pawns in hallways (excluding the current player). Only counts players NOT in rooms, since rooms have infinite capacity.
- **`get_reachable_targets()` method**: 
  - Now excludes the player's current room from reachable rooms (prevents re-entry)
  - Passes occupied positions to `reachable()` to filter out blocked squares
  - Updated docstring to document movement constraints
- **`_handle_move()` method**:
  - Added validation to prevent re-entering the current room
  - Computes occupied positions and passes them to both `reachable()` and `move_towards()`
  - Handles edge case where player cannot move due to all paths being blocked

### Test Coverage (`backend/tests/test_game.py` and `backend/tests/test_board.py`)
- **Game-level tests**: Verify re-entry prevention, occupied hallway blocking, door blocking trapping players, and room capacity behavior
- **Board-level tests**: Test occupied square collision detection, passage blocking, door blocking with secret passages, and room infinite capacity

## Implementation Details
- Occupied squares are only checked for hallway/door types; room nodes are never blocked
- Secret passages remain functional even when doors are blocked
- The reverse BFS in `move_towards()` respects occupied squares to provide accurate distance estimates for pathfinding
- Players in the same room do not interfere with each other's movement

https://claude.ai/code/session_01NBZHhbvBjiu1TDgdTKfASS