### PR TITLE
Strip character name prefix from LLM-generated chat messages

### DIFF
--- a/backend/app/agents.py
+++ b/backend/app/agents.py
@@ -607,6 +607,10 @@ class BaseAgent(ABC):
         if self._pending_chat:
             msg = self._pending_chat
             self._pending_chat = None
+            # Strip leading character name prefix if the LLM included it,
+            # since the caller already prepends "{name}: ".
+            if self.character and msg.startswith(self.character + ": "):
+                msg = msg[len(self.character) + 2:]
             return msg
 
         prob = _CHAT_PROBABILITY.get(action_type, 0.5)


### PR DESCRIPTION
## Summary
Fixed an issue where chat messages generated by the LLM could contain duplicate character name prefixes when the LLM included the prefix in its output.

## Changes
- Added logic to detect and remove character name prefixes from LLM-generated messages
- When a message starts with "{character_name}: ", the prefix is stripped before returning
- This prevents duplication since the caller already prepends the character name to the message

## Implementation Details
- The check only applies when a character is defined (`self.character` is not None)
- The prefix removal uses string slicing to extract the message content after the "{name}: " prefix
- This handles cases where the LLM model outputs the character name as part of its response, which is common behavior for some models

https://claude.ai/code/session_01WZuNEN7X9Q8uPfkQTyqNgH