### PR TITLE
Fix: exclude secret passage rooms from dice-based reachability

### DIFF
--- a/backend/app/board.py
+++ b/backend/app/board.py
@@ -331,6 +331,7 @@ def reachable(
     squares: dict,
     room_nodes: dict[Room, Square],
     occupied: set[tuple[int, int]] | None = None,
+    use_secret_passages: bool = True,
 ) -> dict[Square, int]:
     """
     BFS from `start` up to `steps` moves.
@@ -342,6 +343,10 @@ def reachable(
         Hallway/door/start squares in this set are impassable (cannot be
         entered or passed through).  Room nodes are never blocked — rooms
         have infinite capacity.
+
+    use_secret_passages: if False, room-to-room edges (secret passages)
+        are ignored.  Secret passages are an alternative to rolling the
+        dice, so they should be excluded from dice-based reachability.
     """
     if occupied is None:
         occupied = set()
@@ -353,6 +358,10 @@ def reachable(
         sq, dist = queue.popleft()
 
         for nb in sq.neighbors:
+            # Skip secret passage edges (room-to-room) when not allowed
+            if not use_secret_passages and sq.type == SquareType.ROOM and nb.type == SquareType.ROOM:
+                continue
+
             # Hallway/door/start squares occupied by other pawns are
             # impassable — cannot land on or pass through.
             if nb.type != SquareType.ROOM and (nb.row, nb.col) in occupied:
@@ -492,6 +501,7 @@ def move_towards(
     squares: dict,
     room_nodes: dict[Room, Square],
     occupied: set[tuple[int, int]] | None = None,
+    use_secret_passages: bool = True,
 ) -> tuple[Square, bool]:
     """
     Given a current location, a target room, and a dice roll, attempt to move
@@ -503,11 +513,14 @@ def move_towards(
 
     occupied: forwarded to reachable() and the reverse BFS so that
         hallway squares blocked by other pawns are avoided.
+
+    use_secret_passages: forwarded to reachable() to control whether
+        secret passage edges are considered.
     """
     if occupied is None:
         occupied = set()
 
-    reachable_squares = reachable(start, dice, squares, room_nodes, occupied)
+    reachable_squares = reachable(start, dice, squares, room_nodes, occupied, use_secret_passages)
     target_node = room_nodes[target_room]
 
     # If the target room is directly reachable, move there
@@ -524,6 +537,8 @@ def move_towards(
     while bfs_queue:
         sq, dist = bfs_queue.popleft()
         for nb in sq.neighbors:
+            if not use_secret_passages and sq.type == SquareType.ROOM and nb.type == SquareType.ROOM:
+                continue
             if nb.type != SquareType.ROOM and (nb.row, nb.col) in occupied:
                 continue
             if (sq.type == SquareType.ROOM and nb.type == SquareType.DOOR) or (

--- a/backend/app/game.py
+++ b/backend/app/game.py
@@ -383,7 +383,7 @@ class ClueGame:
             return {"reachable_rooms": list(ROOMS), "reachable_positions": []}
 
         occupied = self._get_occupied_positions(state, player_id)
-        reached = reachable(start_sq, dice, _SQUARES, _ROOM_NODES, occupied)
+        reached = reachable(start_sq, dice, _SQUARES, _ROOM_NODES, occupied, use_secret_passages=False)
 
         rooms = []
         positions = []
@@ -532,7 +532,7 @@ class ClueGame:
 
             if start_sq:
                 reachable_squares = reachable(
-                    start_sq, total, _SQUARES, _ROOM_NODES, occupied
+                    start_sq, total, _SQUARES, _ROOM_NODES, occupied, use_secret_passages=False
                 )
                 if target_sq in reachable_squares:
                     state.current_room.pop(player_id, None)
@@ -560,7 +560,7 @@ class ClueGame:
             if start_sq and target_room_enum:
                 dest, reached = move_towards(
                     start_sq, target_room_enum, total, _SQUARES, _ROOM_NODES,
-                    occupied,
+                    occupied, use_secret_passages=False,
                 )
                 if reached:
                     # Player reaches the room

--- a/backend/tests/test_board.py
+++ b/backend/tests/test_board.py
@@ -86,6 +86,15 @@ def test_reachable_from_room_via_secret_passage(board):
     assert room_nodes[Room.KITCHEN] in reached
 
 
+def test_reachable_excludes_secret_passage_when_disabled(board):
+    """With use_secret_passages=False, secret passage rooms are not reachable."""
+    squares, room_nodes = board
+    study = room_nodes[Room.STUDY]
+    reached = reachable(study, 6, squares, room_nodes, use_secret_passages=False)
+    # Kitchen should NOT be reachable via secret passage
+    assert room_nodes[Room.KITCHEN] not in reached
+
+
 def test_door_does_not_cost_extra_step_leaving_room(board):
     """Leaving a room through a door should not count the door as an extra square.
 

--- a/backend/tests/test_game.py
+++ b/backend/tests/test_game.py
@@ -1004,8 +1004,36 @@ async def test_door_blocking_prevents_exit(game: ClueGame):
     targets = game.get_reachable_targets(whose_turn, state, 6)
     # No hallway positions reachable
     assert len(targets["reachable_positions"]) == 0
-    # Secret passage to Lounge still works
-    assert "Lounge" in targets["reachable_rooms"]
+    # Secret passage rooms should NOT appear in dice-based reachability
+    # (secret passages are used instead of rolling, not after rolling)
+    assert "Lounge" not in targets["reachable_rooms"]
+
+
+@pytest.mark.asyncio
+async def test_secret_passage_rooms_excluded_from_dice_reachability(game: ClueGame):
+    """Secret passage destinations should not appear in get_reachable_targets.
+
+    Secret passages are an alternative to rolling the dice, so after rolling
+    they must not show up as reachable rooms.
+    """
+    await _add_two_players(game)
+    state = await game.start()
+    whose_turn = state.whose_turn
+
+    # Place player in Study (has secret passage to Kitchen)
+    st = await game._load_state()
+    st.current_room[whose_turn] = "Study"
+    center = ROOM_CENTERS.get("Study")
+    if center:
+        st.player_positions[whose_turn] = list(center)
+    await game._save_state(st)
+
+    state = await game._load_state()
+    targets = game.get_reachable_targets(whose_turn, state, 6)
+    # Kitchen (secret passage from Study) must NOT be in reachable rooms
+    assert "Kitchen" not in targets["reachable_rooms"]
+    # Study (current room) also excluded
+    assert "Study" not in targets["reachable_rooms"]
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
Secret passages are an alternative to rolling the dice, not something used after rolling. Added use_secret_passages parameter to reachable() and move_towards() in board.py, and pass False from game.py when computing dice-based movement targets.

https://claude.ai/code/session_01Uu7i6VviVD6W3by9Wgc3Sj