### PR TITLE
Skip LLM API calls when agent has only one viable option

### DIFF
--- a/backend/app/agents.py
+++ b/backend/app/agents.py
@@ -1482,9 +1482,16 @@ class LLMAgent(BaseAgent):
             len(self.unrefuted_suggestions),
         )
 
-        # Auto-roll: if "roll" is the only meaningful action, skip the LLM call
+        # Auto-roll: if "roll" is the only meaningful action and the agent
+        # hasn't narrowed all categories to one unknown (ready to accuse),
+        # skip the LLM call.
+        can_accuse = (
+            len(unknown_suspects) == 1
+            and len(unknown_weapons) == 1
+            and len(unknown_rooms) == 1
+        )
         non_filler = [a for a in available if a not in ("accuse", "end_turn")]
-        if non_filler == ["roll"]:
+        if non_filler == ["roll"] and not can_accuse:
             logger.info(
                 "[%s:%s] Auto-rolling (only option is roll, skipping LLM call)",
                 self.agent_type,

--- a/backend/app/agents.py
+++ b/backend/app/agents.py
@@ -1482,6 +1482,16 @@ class LLMAgent(BaseAgent):
             len(self.unrefuted_suggestions),
         )
 
+        # Auto-roll: if "roll" is the only meaningful action, skip the LLM call
+        non_filler = [a for a in available if a not in ("accuse", "end_turn")]
+        if non_filler == ["roll"]:
+            logger.info(
+                "[%s:%s] Auto-rolling (only option is roll, skipping LLM call)",
+                self.agent_type,
+                player_id,
+            )
+            return {"type": "roll"}
+
         # Build prompt and call LLM
         personality = _CHARACTER_PERSONALITY_BLURBS.get(self.character, "")
         system_prompt = _ACTION_SYSTEM_PROMPT.format(
@@ -1604,6 +1614,18 @@ class LLMAgent(BaseAgent):
             suggesting_player_id,
             sorted(self.shown_to.get(suggesting_player_id, set())),
         )
+
+        # Auto-show: if only one card matches, show it without calling the LLM
+        if len(matching_cards) == 1:
+            card = matching_cards[0]
+            self.shown_to.setdefault(suggesting_player_id, set()).add(card)
+            logger.info(
+                "[%s] Auto-showing '%s' to %s (only matching card, skipping LLM call)",
+                self.agent_type,
+                card,
+                suggesting_player_id,
+            )
+            return card
 
         user_prompt = self._build_show_card_prompt(matching_cards, suggesting_player_id)
         logger.info(


### PR DESCRIPTION
Auto-roll dice when "roll" is the only meaningful action available (ignoring accuse/end_turn), and auto-show the card when only one matching card exists. This avoids unnecessary OpenAI calls for decisions that have no real choice.

https://claude.ai/code/session_01JAKq1yhRDAuFv5VZuZ1bF5