### PR TITLE
Restore pending show_card_request on websocket reconnect

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -901,6 +901,21 @@ async def websocket_endpoint(websocket: WebSocket, game_id: str, player_id: str)
                     "state": player_state.model_dump(),
                 },
             )
+            # Resend show_card_request if there's a pending one for this player
+            pending = player_state.pending_show_card
+            if pending and pending.player_id == player_id:
+                await manager.send_to_player(
+                    game_id,
+                    player_id,
+                    {
+                        "type": "show_card_request",
+                        "suggesting_player_id": pending.suggesting_player_id,
+                        "suspect": pending.suspect,
+                        "weapon": pending.weapon,
+                        "room": pending.room,
+                        "available_actions": player_state.available_actions,
+                    },
+                )
         while True:
             data = await websocket.receive_text()
             # Clients can send ping/keep-alive or chat messages

--- a/frontend/src/App.vue
+++ b/frontend/src/App.vue
@@ -149,6 +149,18 @@ function handleMessage(msg) {
         gameState.value = msg.state
         if (msg.state.your_cards) yourCards.value = msg.state.your_cards
         if (msg.state.available_actions) availableActions.value = msg.state.available_actions
+        // Restore showCardRequest from pending_show_card on reconnect
+        const pending = msg.state.pending_show_card
+        if (pending && pending.player_id === playerId.value) {
+          showCardRequest.value = {
+            suggestingPlayerId: pending.suggesting_player_id,
+            suspect: pending.suspect,
+            weapon: pending.weapon,
+            room: pending.room,
+          }
+        } else {
+          showCardRequest.value = null
+        }
       } else {
         // Partial update: merge individual fields
         const { type: _type, ...fields } = msg


### PR DESCRIPTION
## Summary
This PR fixes a bug where players would lose pending card show requests when reconnecting to the websocket. The changes ensure that if a player has a pending show_card_request when they reconnect, they are immediately resent the request so they can complete the action.

## Key Changes
- **Backend (main.py)**: Added logic to resend any pending `show_card_request` to a player upon websocket reconnection, including all necessary request details (suggesting_player_id, suspect, weapon, room, and available_actions)
- **Frontend (App.vue)**: Added logic to restore the `showCardRequest` UI state from the `pending_show_card` data received during reconnection, ensuring the UI reflects the pending request immediately

## Implementation Details
- The backend checks if the player has a `pending_show_card` that matches their player_id and resends it with the current available_actions
- The frontend reconstructs the `showCardRequest` object from the pending data structure, mapping snake_case backend fields to camelCase frontend fields
- If there is no pending request or it doesn't match the current player, the showCardRequest is cleared
- This ensures consistency between backend state and frontend UI after a reconnection event

https://claude.ai/code/session_01NFTYHcuLeog2pdnqMKM2Sx