### PR TITLE
Add persistent detective notes with auto-save functionality

### DIFF
--- a/backend/app/game.py
+++ b/backend/app/game.py
@@ -97,6 +97,9 @@ class ClueGame:
     def _memory_key(self, player_id: str) -> str:
         return f"game:{self.game_id}:memory:{player_id}"
 
+    def _notes_key(self, player_id: str) -> str:
+        return f"game:{self.game_id}:notes:{player_id}"
+
     # ------------------------------------------------------------------
     # Internal Redis helpers
     # ------------------------------------------------------------------
@@ -143,6 +146,17 @@ class ClueGame:
         """Retrieve all memory entries for an LLM agent."""
         entries = await self.redis.lrange(self._memory_key(player_id), 0, -1)
         return [e if isinstance(e, str) else e.decode() for e in entries]
+
+    async def save_detective_notes(self, player_id: str, notes: dict):
+        """Save a player's detective notes to Redis."""
+        await self.redis.set(self._notes_key(player_id), json.dumps(notes), ex=EXPIRY)
+
+    async def load_detective_notes(self, player_id: str) -> dict | None:
+        """Load a player's detective notes from Redis."""
+        raw = await self.redis.get(self._notes_key(player_id))
+        if raw is None:
+            return None
+        return json.loads(raw)
 
     async def add_chat_message(self, message: ChatMessage):
         await self.redis.rpush(self._chat_key, message.model_dump_json())
@@ -235,11 +249,13 @@ class ClueGame:
         if state is None:
             return None
         cards = await self._load_player_cards(player_id)
+        notes = await self.load_detective_notes(player_id)
         return PlayerState(
             **state.model_dump(),
             your_cards=cards,
             your_player_id=player_id,
             available_actions=self.get_available_actions(player_id, state),
+            detective_notes=notes,
         )
 
     async def add_player(

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -25,6 +25,7 @@ from .models import (
     JoinRequest,
     Player,
     PlayerState,
+    SaveNotesRequest,
 )
 from .ws_manager import ConnectionManager
 
@@ -950,6 +951,21 @@ async def submit_action(game_id: str, req: ActionRequest):
     if state:
         result["available_actions"] = game.get_available_actions(req.player_id, state)
     return result
+
+
+# ---------------------------------------------------------------------------
+# Detective notes
+# ---------------------------------------------------------------------------
+
+
+@app.put("/games/{game_id}/notes")
+async def save_notes(game_id: str, req: SaveNotesRequest):
+    game = ClueGame(game_id, redis_client)
+    state = await game.get_state()
+    if state is None:
+        raise HTTPException(status_code=404, detail="Game not found")
+    await game.save_detective_notes(req.player_id, req.notes)
+    return {"ok": True}
 
 
 # ---------------------------------------------------------------------------

--- a/backend/app/models.py
+++ b/backend/app/models.py
@@ -59,6 +59,7 @@ class PlayerState(GameState):
     your_cards: list[str] = Field(default_factory=list)
     your_player_id: str = ""
     available_actions: list[str] = Field(default_factory=list)
+    detective_notes: Optional[dict] = None
 
 
 class ChatMessage(BaseModel):
@@ -89,3 +90,8 @@ class ActionRequest(BaseModel):
 class ChatRequest(BaseModel):
     player_id: str
     text: str
+
+
+class SaveNotesRequest(BaseModel):
+    player_id: str
+    notes: dict

--- a/frontend/src/App.vue
+++ b/frontend/src/App.vue
@@ -30,6 +30,7 @@
       :auto-end-timer="autoEndTimer"
       :reachable-rooms="reachableRooms"
       :reachable-positions="reachablePositions"
+      :saved-notes="savedNotes"
       @action="sendAction"
       @send-chat="sendChat"
       @dismiss-card-shown="cardShown = null"
@@ -56,6 +57,7 @@ const urlGameId = ref(null)
 const autoEndTimer = ref(null)
 const reachableRooms = ref([])
 const reachablePositions = ref([])
+const savedNotes = ref(null)
 
 const gameStatus = computed(() => gameState.value?.status ?? 'waiting')
 const players = computed(() => gameState.value?.players ?? [])
@@ -149,6 +151,8 @@ function handleMessage(msg) {
         gameState.value = msg.state
         if (msg.state.your_cards) yourCards.value = msg.state.your_cards
         if (msg.state.available_actions) availableActions.value = msg.state.available_actions
+        // Restore detective notes on reconnect
+        if (msg.state.detective_notes) savedNotes.value = msg.state.detective_notes
         // Restore showCardRequest from pending_show_card on reconnect
         const pending = msg.state.pending_show_card
         if (pending && pending.player_id === playerId.value) {
@@ -310,6 +314,7 @@ function resetState() {
   autoEndTimer.value = null
   reachableRooms.value = []
   reachablePositions.value = []
+  savedNotes.value = null
 }
 
 function leaveGame() {

--- a/frontend/src/components/DetectiveNotes.vue
+++ b/frontend/src/components/DetectiveNotes.vue
@@ -61,12 +61,37 @@ const CYCLE = ['', 'no', 'maybe', '']
 
 const props = defineProps({
   yourCards: { type: Array, default: () => [] },
+  savedNotes: { type: Object, default: null },
 })
+
+const emit = defineEmits(['notes-changed'])
 
 // notes: card -> state string
 const notes = reactive({})
 // Track who showed each card
 const shownByMap = reactive({})
+// Flag to prevent emitting during restoration
+let restoring = false
+
+// Restore saved notes when they arrive (e.g. on rejoin)
+watch(
+  () => props.savedNotes,
+  (saved) => {
+    if (saved) {
+      restoring = true
+      const noteStates = saved.notes || {}
+      const shownBy = saved.shownBy || {}
+      for (const [card, state] of Object.entries(noteStates)) {
+        notes[card] = state
+      }
+      for (const [card, by] of Object.entries(shownBy)) {
+        shownByMap[card] = by
+      }
+      restoring = false
+    }
+  },
+  { immediate: true }
+)
 
 // Auto-mark cards in hand
 watch(
@@ -78,6 +103,17 @@ watch(
   },
   { immediate: true }
 )
+
+function emitNotesChanged() {
+  if (restoring) return
+  emit('notes-changed', {
+    notes: { ...notes },
+    shownBy: { ...shownByMap },
+  })
+}
+
+// Watch for any notes changes and emit
+watch(notes, () => emitNotesChanged(), { deep: true })
 
 function noteMark(card) {
   const state = notes[card] ?? ''

--- a/frontend/src/components/GameBoard.vue
+++ b/frontend/src/components/GameBoard.vue
@@ -251,7 +251,7 @@
 
         <!-- Detective Notes -->
         <section v-if="!isObserver" class="sidebar-panel notes-panel">
-          <DetectiveNotes ref="notesRef" :your-cards="yourCards" />
+          <DetectiveNotes ref="notesRef" :your-cards="yourCards" :saved-notes="savedNotes" @notes-changed="onNotesChanged" />
         </section>
       </div>
     </div>
@@ -310,6 +310,7 @@ const props = defineProps({
   autoEndTimer: { type: Object, default: null },
   reachableRooms: { type: Array, default: () => [] },
   reachablePositions: { type: Array, default: () => [] },
+  savedNotes: { type: Object, default: null },
 })
 
 const emit = defineEmits(['action', 'send-chat', 'dismiss-card-shown'])
@@ -474,6 +475,23 @@ function doAccuse() {
 function doEndTurn() {
   emit('action', { type: 'end_turn' })
 }
+
+// Debounced save of detective notes to backend
+let saveNotesTimer = null
+function onNotesChanged(notesData) {
+  if (saveNotesTimer) clearTimeout(saveNotesTimer)
+  saveNotesTimer = setTimeout(() => {
+    fetch(`/games/${props.gameId}/notes`, {
+      method: 'PUT',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ player_id: props.playerId, notes: notesData }),
+    }).catch(() => {})
+  }, 500)
+}
+
+onUnmounted(() => {
+  if (saveNotesTimer) clearTimeout(saveNotesTimer)
+})
 
 // Auto-mark shown cards in detective notes
 watch(


### PR DESCRIPTION
## Summary
This PR adds persistence for detective notes in the Clue game. Players' notes are now automatically saved to the backend and restored when they rejoin a game, ensuring their progress is not lost.

## Key Changes

**Frontend (Vue components):**
- Modified `DetectiveNotes.vue` to emit a `notes-changed` event whenever notes are modified
- Added a watcher to restore saved notes from props when they arrive (e.g., on rejoin)
- Implemented a `restoring` flag to prevent emitting events during restoration to avoid unnecessary saves
- Added deep watching of the notes object to detect all changes

**Frontend (App state management):**
- Added `savedNotes` ref to track detective notes state
- Updated `GameBoard.vue` to pass `savedNotes` prop to `DetectiveNotes` and handle the `notes-changed` event
- Implemented debounced saving (500ms) to avoid excessive API calls when notes change rapidly
- Properly clean up timers on component unmount

**Backend (Game logic):**
- Added `_notes_key()` helper method to generate Redis keys for storing notes per player
- Implemented `save_detective_notes()` to persist notes to Redis with expiry
- Implemented `load_detective_notes()` to retrieve saved notes from Redis
- Updated `get_player_state()` to include detective notes in the player state response

**Backend (API):**
- Added new `PUT /games/{game_id}/notes` endpoint to save detective notes
- Created `SaveNotesRequest` model for the notes save request
- Updated `PlayerState` model to include optional `detective_notes` field

## Implementation Details

- Notes are stored in Redis with the same expiry as other game data, ensuring they're cleaned up when games expire
- The frontend uses a 500ms debounce on saves to batch rapid changes and reduce server load
- A `restoring` flag prevents feedback loops when notes are restored from the server
- The restoration happens immediately when `savedNotes` prop is set, allowing seamless rejoin experience

https://claude.ai/code/session_01MtASg8dz3eyAnBjC9VKno2