### PR TITLE
Add inference notification system for LLM agents

### DIFF
--- a/backend/app/agents.py
+++ b/backend/app/agents.py
@@ -482,6 +482,8 @@ class BaseAgent(ABC):
         self.player_has_cards: dict[str, set[str]] = {}
         self.player_not_has_cards: dict[str, set[str]] = {}
         self.suggestion_log: list[dict] = []
+        # Accumulate inference notifications for LLM agents to consume
+        self._pending_inferences: list[str] = []
         logger.info("[%s] Agent instance created", self.agent_type)
 
     # ------------------------------------------------------------------
@@ -511,12 +513,21 @@ class BaseAgent(ABC):
             len(self.seen_cards),
         )
         if is_new:
+            by_text = f" by {shown_by}" if shown_by else ""
+            self._pending_inferences.append(
+                f"CARD SHOWN: '{card}' was shown to me{by_text}. "
+                f"This card is NOT the solution."
+            )
             self._run_inference()
 
     def observe_suggestion_no_show(self, suspect: str, weapon: str, room: str):
         """Called when a suggestion gets no card shown by anyone."""
         self.unrefuted_suggestions.append(
             {"suspect": suspect, "weapon": weapon, "room": room}
+        )
+        self._pending_inferences.append(
+            f"UNREFUTED: My suggestion of {suspect}/{weapon}/{room} was not "
+            f"disproved by anyone! These could all be the solution."
         )
         logger.info(
             "[%s] Unrefuted suggestion: %s / %s / %s (total_unrefuted=%d)",
@@ -548,6 +559,11 @@ class BaseAgent(ABC):
                 suspect,
                 weapon,
                 room,
+            )
+            self._pending_inferences.append(
+                f"DEDUCED: {shown_by} showed a card to {shown_to} for "
+                f"{suspect}/{weapon}/{room}. By elimination I deduced the "
+                f"card was '{inferred}' — it is NOT the solution."
             )
             self._run_inference()
         else:
@@ -631,6 +647,18 @@ class BaseAgent(ABC):
         for pid in players_without_match:
             self.player_not_has_cards.setdefault(pid, set()).update(suggested_cards)
 
+        if players_without_match:
+            pids = ", ".join(players_without_match)
+            self._pending_inferences.append(
+                f"NEGATIVE: {suggesting_player_id} suggested {suspect}/{weapon}/{room}. "
+                f"Players [{pids}] could NOT show any of these cards."
+            )
+        if shown_by and shown_by != self.player_id and suggesting_player_id != self.player_id:
+            self._pending_inferences.append(
+                f"OBSERVED: {shown_by} showed a card to {suggesting_player_id} "
+                f"for {suspect}/{weapon}/{room}."
+            )
+
         logger.debug(
             "[%s] Observed suggestion: %s suggested %s/%s/%s, shown_by=%s, "
             "%d players couldn't show",
@@ -687,6 +715,11 @@ class BaseAgent(ABC):
                         suspect,
                         weapon,
                         room,
+                    )
+                    self._pending_inferences.append(
+                        f"DEDUCED (chain): From earlier suggestion "
+                        f"{suspect}/{weapon}/{room}, I now deduce {shown_by} "
+                        f"has '{inferred}' — it is NOT the solution."
                     )
                     changed = True
 
@@ -1146,7 +1179,12 @@ When the action is end_turn, also include a "memory" field with your private det
 suspicions, which cards you've eliminated, your strategy for next turns. These \
 notes will be shown back to you on your next turn so you can remember your \
 reasoning. Be concise but thorough. \
-You will always get the known/unkonwn cards and suggestion history as part of the game state, so focus on insights and plans rather than repeating raw facts.\
+You will always get the known/unknown cards and suggestion history as part of the game state, so focus on insights and plans rather than repeating raw facts.
+
+INFERENCE LOG: Your notes section may contain automatic inference notifications \
+(prefixed CARD SHOWN, DEDUCED, NEGATIVE, UNREFUTED, OBSERVED). These are events \
+the game engine tracked between your turns. Pay close attention to DEDUCED entries — \
+they reveal cards eliminated by logical deduction. Use these to refine your strategy.\
 """
 
 # Personality blurbs injected into the LLM system prompt per character.
@@ -1264,6 +1302,20 @@ class LLMAgent(BaseAgent):
 
             game = ClueGame(self._game_id, self._redis)
             await game.append_memory(self.player_id, entry)
+
+    async def _flush_pending_inferences(self):
+        """Save any accumulated inference notifications to memory."""
+        if not self._pending_inferences:
+            return
+        # Combine all pending inferences into a single memory entry
+        entry = "INFERENCE UPDATE: " + " | ".join(self._pending_inferences)
+        self._pending_inferences.clear()
+        await self._save_memory_entry(entry)
+        logger.info(
+            "[%s:%s] Flushed inference notifications to memory",
+            self.agent_type,
+            self.player_id,
+        )
 
     # ------------------------------------------------------------------
     # LLM communication
@@ -1443,11 +1495,15 @@ class LLMAgent(BaseAgent):
                 f"{self.unrefuted_suggestions}"
             )
 
-        # Include memory from previous turns
+        # Include memory from previous turns (recent entries, capped to avoid
+        # overwhelming the prompt)
         if self.memory:
             lines.append("")
-            lines.append("YOUR PRIVATE NOTES FROM PREVIOUS TURNS:")
-            lines.append(f"  Turn {len(self.memory)}: {self.memory[-1]}")
+            lines.append("YOUR PRIVATE NOTES AND INFERENCE LOG:")
+            recent = self.memory[-10:]  # last 10 entries
+            start_idx = len(self.memory) - len(recent) + 1
+            for i, entry in enumerate(recent):
+                lines.append(f"  [{start_idx + i}] {entry}")
 
         lines.append("")
         lines.append("Choose your action. Valid action formats:")
@@ -1566,6 +1622,9 @@ class LLMAgent(BaseAgent):
     async def decide_action(
         self, game_state: GameState, player_state: PlayerState
     ) -> dict:
+        # Flush any inference notifications accumulated since last decision
+        await self._flush_pending_inferences()
+
         player_id = player_state.your_player_id
         available = player_state.available_actions
         current_room = game_state.current_room.get(player_id)
@@ -1724,6 +1783,9 @@ class LLMAgent(BaseAgent):
     async def decide_show_card(
         self, matching_cards: list[str], suggesting_player_id: str
     ) -> str:
+        # Flush any inference notifications before making a decision
+        await self._flush_pending_inferences()
+
         logger.info(
             "[%s] Deciding which card to show to %s from %s",
             self.agent_type,


### PR DESCRIPTION
## Summary
This PR implements an inference notification system that accumulates game events and logical deductions, making them available to LLM agents through their memory system. This allows agents to better track and reason about card eliminations and game state changes between their turns.

## Key Changes
- **Inference accumulation**: Added `_pending_inferences` list to track game events (card shows, deductions, negative information, unrefuted suggestions, and observations)
- **Event logging**: Integrated inference notifications at key decision points:
  - When cards are shown (`observe_shown_card`)
  - When suggestions go unrefuted (`observe_suggestion_no_show`)
  - When cards are deduced by elimination (`observe_card_shown_to_other`)
  - When suggestions are observed with negative/positive information (`observe_suggestion`)
  - When chain deductions occur during inference (`_run_inference`)
- **Memory flushing**: Added `_flush_pending_inferences()` method that combines accumulated inferences into a single memory entry prefixed with "INFERENCE UPDATE:"
- **Decision point integration**: Flush pending inferences before LLM decision-making in both `decide_action()` and `decide_show_card()`
- **Prompt improvements**:
  - Updated system prompt to explain inference log format and emphasize DEDUCED entries
  - Fixed typo: "unkonwn" → "unknown"
  - Enhanced memory display to show last 10 entries with indices instead of just the most recent entry
  - Added context about inference notifications in the notes section instructions

## Implementation Details
- Inference notifications use consistent prefixes (CARD SHOWN, DEDUCED, NEGATIVE, UNREFUTED, OBSERVED) for easy parsing
- Notifications are accumulated during game events and flushed to memory only when the agent needs to make a decision, avoiding redundant memory entries
- The system preserves logical deduction chains, allowing agents to understand not just what cards are eliminated but why
- Memory display now shows up to 10 recent entries to provide better context while avoiding prompt bloat

https://claude.ai/code/session_01Aj6EdLLRuJ6jK19EPqFm9f