### PR TITLE
Fix turn progression logic to require move before ending turn

### DIFF
--- a/backend/app/game.py
+++ b/backend/app/game.py
@@ -219,6 +219,13 @@ class ClueGame:
         current_room = state.current_room.get(player_id)
         suggestions_made = bool(state.suggestions_this_turn)
 
+        # After making a suggestion, you can only accuse or end turn
+        # (no more rolling/moving this turn).
+        if suggestions_made:
+            actions.append("accuse")
+            actions.append("end_turn")
+            return actions
+
         if not state.dice_rolled and not state.moved:
             # Phase 1: before rolling — offer passage (if applicable) and roll
             if current_room and current_room in SECRET_PASSAGE_MAP:
@@ -227,7 +234,6 @@ class ClueGame:
             # If pulled into a room by a suggestion, can suggest without rolling
             if (
                 current_room
-                and not suggestions_made
                 and state.was_moved_by_suggestion.get(player_id)
             ):
                 actions.append("suggest")
@@ -241,10 +247,11 @@ class ClueGame:
         actions.append("accuse")
 
         # Only offer end_turn if the player has done something this turn
+        # and doesn't still need to move (Phase 2).
         has_acted = (
             state.dice_rolled or state.moved or bool(state.suggestions_this_turn)
         )
-        if has_acted:
+        if has_acted and "move" not in actions:
             actions.append("end_turn")
 
         return actions

--- a/backend/tests/test_game.py
+++ b/backend/tests/test_game.py
@@ -36,6 +36,13 @@ async def _add_two_players(game: ClueGame):
     return p1, p2
 
 
+async def _advance_turn(game: ClueGame, player_id: str):
+    """Advance past a player's turn by rolling, moving, and ending turn."""
+    await game.process_action(player_id, {"type": "roll"})
+    await game.process_action(player_id, {"type": "move", "room": ROOMS[0]})
+    await game.process_action(player_id, {"type": "end_turn"})
+
+
 async def _place_player_in_room(game: ClueGame, player_id: str, room: str):
     """Directly place a player in a room and mark dice as rolled and moved."""
     state = await game._load_state()
@@ -266,8 +273,9 @@ async def test_end_turn_advances_player(game: ClueGame):
     first_player = state.whose_turn
     second_player = "P2" if first_player == "P1" else "P1"
 
-    # Player must do something before ending turn (roll dice first)
+    # Player must roll and move before ending turn
     await game.process_action(first_player, {"type": "roll"})
+    await game.process_action(first_player, {"type": "move", "room": ROOMS[0]})
     result = await game.process_action(first_player, {"type": "end_turn"})
     assert result.next_player_id == second_player
 
@@ -556,13 +564,14 @@ async def test_roll_then_move(game: ClueGame):
     assert result.type == "roll"
     assert result.dice >= 1
 
-    # After rolling: move is available, roll is not
+    # After rolling: move is available, roll and end_turn are not
     state = await game.get_state()
     assert state.dice_rolled is True
     assert state.moved is False
     actions = game.get_available_actions(whose_turn, state)
     assert "move" in actions
     assert "roll" not in actions
+    assert "end_turn" not in actions  # must move before ending turn
 
     # Choose a room
     room = ROOMS[0]
@@ -748,8 +757,7 @@ async def test_suggest_available_without_roll_after_moved_by_suggestion(game: Cl
     while state.whose_turn != other_id:
         # Advance past wanderer turns
         wt = state.whose_turn
-        await game.process_action(wt, {"type": "roll"})
-        await game.process_action(wt, {"type": "end_turn"})
+        await _advance_turn(game, wt)
         state = await game.get_state()
 
     assert state.whose_turn == other_id
@@ -791,8 +799,7 @@ async def test_free_suggest_then_end_turn(game: ClueGame):
     state = await game.get_state()
     while state.whose_turn != other_id:
         wt = state.whose_turn
-        await game.process_action(wt, {"type": "roll"})
-        await game.process_action(wt, {"type": "end_turn"})
+        await _advance_turn(game, wt)
         state = await game.get_state()
 
     # Use the free suggest
@@ -810,11 +817,14 @@ async def test_free_suggest_then_end_turn(game: ClueGame):
             result.pending_show_by, {"type": "show_card", "card": matching[0]}
         )
 
-    # Should be able to end turn now
+    # After suggesting: only accuse and end_turn available (no roll/move)
     state = await game.get_state()
     actions = game.get_available_actions(other_id, state)
     assert "end_turn" in actions
+    assert "accuse" in actions
     assert "suggest" not in actions  # already suggested this turn
+    assert "roll" not in actions     # can't roll after suggesting
+    assert "move" not in actions     # can't move after suggesting
 
     await game.process_action(other_id, {"type": "end_turn"})
 
@@ -849,15 +859,15 @@ async def test_flag_cleared_after_turn_ends(game: ClueGame):
     state = await game.get_state()
     while state.whose_turn != other_id:
         wt = state.whose_turn
-        await game.process_action(wt, {"type": "roll"})
-        await game.process_action(wt, {"type": "end_turn"})
+        await _advance_turn(game, wt)
         state = await game.get_state()
 
     # Flag is set
     assert state.was_moved_by_suggestion.get(other_id) is True
 
-    # Roll and end turn (choosing not to use free suggest)
+    # Roll, move, and end turn (choosing not to use free suggest)
     await game.process_action(other_id, {"type": "roll"})
+    await game.process_action(other_id, {"type": "move", "room": ROOMS[1]})
     await game.process_action(other_id, {"type": "end_turn"})
 
     # Flag should be cleared


### PR DESCRIPTION
## Summary
This PR fixes the turn progression logic in the Clue game to properly enforce that players must roll and move before ending their turn, and that after making a suggestion, no further rolling or moving is allowed.

## Key Changes

- **Added `_advance_turn()` helper function** in tests to encapsulate the full turn sequence (roll → move → end_turn), reducing code duplication across multiple test cases

- **Fixed `get_available_actions()` logic** to:
  - Return early with only "accuse" and "end_turn" options after a suggestion is made (preventing roll/move after suggesting)
  - Prevent "end_turn" from being available during Phase 2 (after rolling but before moving)
  - Only allow "end_turn" once a player has both rolled AND moved

- **Updated test assertions** to verify the corrected behavior:
  - `test_roll_then_move`: Added assertion that "end_turn" is not available until after moving
  - `test_free_suggest_then_end_turn`: Added assertions confirming roll/move are unavailable after suggesting
  - `test_flag_cleared_after_turn_ends`: Updated to include the required move action in the turn sequence

- **Removed redundant condition** in `get_available_actions()` that was checking `not suggestions_made` when offering the free suggest after being moved by suggestion (this is now handled by the early return)

## Implementation Details
The fix ensures proper turn state progression by enforcing a strict sequence: roll → move → (optional suggest) → end_turn. The early return when suggestions have been made prevents players from rolling or moving again after making a suggestion, which aligns with the game rules.

https://claude.ai/code/session_0122ZtfXrBoRymgDPVa4y4ja