### PR TITLE
Add LLM trace logging level configuration support

### DIFF
--- a/backend/agent_runner.py
+++ b/backend/agent_runner.py
@@ -412,7 +412,8 @@ if __name__ == "__main__":
 
     log_level = os.getenv("LOG_LEVEL", "INFO").upper()
     log_format = os.getenv("LOG_FORMAT", "colored")
+    trace_level = os.getenv("LLM_TRACE_LOG_LEVEL", "").strip().upper()
     logging.config.dictConfig(
-        get_logging_config(log_level=log_level, log_format=log_format)
+        get_logging_config(log_level=log_level, trace_level=trace_level, log_format=log_format)
     )
     asyncio.run(main())


### PR DESCRIPTION
## Summary
Added support for configurable LLM trace logging level through environment variable, allowing users to control the verbosity of LLM-related trace logs independently from the main log level.

## Key Changes
- Added `LLM_TRACE_LOG_LEVEL` environment variable support to configure trace logging level
- Updated `get_logging_config()` call to pass the new `trace_level` parameter
- The trace level is extracted from the environment variable, stripped of whitespace, and converted to uppercase for consistency

## Implementation Details
- The `trace_level` defaults to an empty string if the `LLM_TRACE_LOG_LEVEL` environment variable is not set
- The value is normalized using `.strip().upper()` to handle various input formats
- This allows fine-grained control over LLM trace logging without affecting the overall application log level

https://claude.ai/code/session_012LBCAYMx4SVYyrSeZjErEz