### PR TITLE
Add auto-show-card timer for human players with one matching card

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -31,6 +31,7 @@ from .models import (
     ActionResult,
     AddAgentRequest,
     AutoEndTimerMessage,
+    AutoShowCardTimerMessage,
     CardShownMessage,
     CardShownPublicMessage,
     ChatBroadcastMessage,
@@ -93,6 +94,10 @@ async def lifespan(app: FastAPI):
     for task in _auto_end_timers.values():
         task.cancel()
     _auto_end_timers.clear()
+    # Cancel any auto-show-card timers
+    for task in _auto_show_card_timers.values():
+        task.cancel()
+    _auto_show_card_timers.clear()
     await redis_client.aclose()
 
 
@@ -121,6 +126,10 @@ _agent_tasks: dict[str, asyncio.Task] = {}
 # Auto-end-turn timers: game_id -> asyncio.Task
 _auto_end_timers: dict[str, asyncio.Task] = {}
 AUTO_END_TURN_SECONDS = 7
+
+# Auto-show-card timers: game_id -> asyncio.Task
+_auto_show_card_timers: dict[str, asyncio.Task] = {}
+AUTO_SHOW_CARD_SECONDS = 7
 
 # Player types that trigger the automated agent loop
 _AGENT_PLAYER_TYPES = {"agent", "llm_agent", "wanderer"}
@@ -245,6 +254,79 @@ async def _maybe_start_auto_end_timer(game_id: str):
 
 
 # ---------------------------------------------------------------------------
+# Auto-show-card timer helpers
+# ---------------------------------------------------------------------------
+
+
+def _cancel_auto_show_card_timer(game_id: str):
+    """Cancel any pending auto-show-card timer for a game."""
+    task = _auto_show_card_timers.pop(game_id, None)
+    if task and not task.done():
+        task.cancel()
+
+
+async def _auto_show_card_task(
+    game_id: str, player_id: str, card: str, turn_number: int
+):
+    """Wait AUTO_SHOW_CARD_SECONDS then auto-show the only matching card."""
+    try:
+        await asyncio.sleep(AUTO_SHOW_CARD_SECONDS)
+        _auto_show_card_timers.pop(game_id, None)
+        game = ClueGame(game_id, redis_client)
+        state = await game.get_state()
+        if (
+            state
+            and state.status == "playing"
+            and state.pending_show_card
+            and state.pending_show_card.player_id == player_id
+            and state.turn_number == turn_number
+        ):
+            logger.info(
+                "Auto-showing card for player %s in game %s (turn %d)",
+                player_id,
+                game_id,
+                turn_number,
+            )
+            await _execute_action(game_id, player_id, ShowCardAction(card=card))
+    except asyncio.CancelledError:
+        pass
+    except Exception:
+        logger.exception("Auto-show-card error in game %s", game_id)
+    finally:
+        _auto_show_card_timers.pop(game_id, None)
+
+
+async def _maybe_start_auto_show_card_timer(game_id: str):
+    """Start an auto-show timer if a human player has exactly one matching card."""
+    game = ClueGame(game_id, redis_client)
+    state = await game.get_state()
+    if not state or state.status != "playing":
+        return
+    pending = state.pending_show_card
+    if not pending:
+        return
+    # Only apply to human players
+    player = next((p for p in state.players if p.id == pending.player_id), None)
+    if not player or player.type in _AGENT_PLAYER_TYPES:
+        return
+    if len(pending.matching_cards) == 1:
+        _cancel_auto_show_card_timer(game_id)
+        task = asyncio.create_task(
+            _auto_show_card_task(
+                game_id, pending.player_id, pending.matching_cards[0], state.turn_number
+            )
+        )
+        _auto_show_card_timers[game_id] = task
+        await manager.send_to_player(
+            game_id,
+            pending.player_id,
+            AutoShowCardTimerMessage(
+                player_id=pending.player_id, seconds=AUTO_SHOW_CARD_SECONDS
+            ),
+        )
+
+
+# ---------------------------------------------------------------------------
 # Action execution (shared by HTTP endpoint and agent loop)
 # ---------------------------------------------------------------------------
 
@@ -256,8 +338,9 @@ async def _execute_action(
 
     Returns the typed action result. Raises ValueError on invalid actions.
     """
-    # Cancel any pending auto-end timer when a player takes an action
+    # Cancel any pending auto-end / auto-show-card timer when a player takes an action
     _cancel_auto_end_timer(game_id)
+    _cancel_auto_show_card_timer(game_id)
 
     game = ClueGame(game_id, redis_client)
     result = await game.process_action(player_id, action)
@@ -394,6 +477,8 @@ async def _execute_action(
                     available_actions=game.get_available_actions(player_id, state),
                 ),
             )
+            # Auto-show if the player has exactly one matching card
+            await _maybe_start_auto_show_card_timer(game_id)
             chat_text = (
                 f"{actor_name} suggests {result.suspect} with the {result.weapon}"
                 f" in the {result.room}. {pending_by_name} must show a card."

--- a/backend/app/models.py
+++ b/backend/app/models.py
@@ -304,6 +304,12 @@ class AutoEndTimerMessage(WSMessage):
     seconds: int
 
 
+class AutoShowCardTimerMessage(WSMessage):
+    type: Literal["auto_show_card_timer"] = "auto_show_card_timer"
+    player_id: str
+    seconds: int
+
+
 class PlayerJoinedMessage(WSMessage):
     type: Literal["player_joined"] = "player_joined"
     player: Player

--- a/frontend/src/App.vue
+++ b/frontend/src/App.vue
@@ -28,6 +28,7 @@
       :chat-messages="chatMessages"
       :is-observer="isObserver"
       :auto-end-timer="autoEndTimer"
+      :auto-show-card-timer="autoShowCardTimer"
       :reachable-rooms="reachableRooms"
       :reachable-positions="reachablePositions"
       :saved-notes="savedNotes"
@@ -55,6 +56,7 @@ const chatMessages = ref([])
 const isObserver = ref(false)
 const urlGameId = ref(null)
 const autoEndTimer = ref(null)
+const autoShowCardTimer = ref(null)
 const reachableRooms = ref([])
 const reachablePositions = ref([])
 const savedNotes = ref(null)
@@ -171,6 +173,7 @@ function handleMessage(msg) {
         gameState.value = { ...gameState.value, ...fields }
       }
       autoEndTimer.value = null
+      autoShowCardTimer.value = null
       reachableRooms.value = []
       reachablePositions.value = []
       break
@@ -203,6 +206,10 @@ function handleMessage(msg) {
 
     case 'auto_end_timer':
       autoEndTimer.value = { playerId: msg.player_id, seconds: msg.seconds, startedAt: Date.now() }
+      break
+
+    case 'auto_show_card_timer':
+      autoShowCardTimer.value = { playerId: msg.player_id, seconds: msg.seconds, startedAt: Date.now() }
       break
 
     case 'show_card_request':
@@ -254,12 +261,14 @@ function handleMessage(msg) {
       cardShown.value = { card: msg.card, by: msg.shown_by }
       if (msg.available_actions) availableActions.value = msg.available_actions
       showCardRequest.value = null
+      autoShowCardTimer.value = null
       break
 
     case 'card_shown_public':
       // A card was shown between two players (we don't see which card)
       // Clear any pending show card state
       showCardRequest.value = null
+      autoShowCardTimer.value = null
       break
 
     case 'accusation_made':
@@ -278,6 +287,7 @@ function handleMessage(msg) {
       }
       availableActions.value = []
       autoEndTimer.value = null
+      autoShowCardTimer.value = null
       break
 
     case 'chat_message':
@@ -312,6 +322,7 @@ function resetState() {
   chatMessages.value = []
   isObserver.value = false
   autoEndTimer.value = null
+  autoShowCardTimer.value = null
   reachableRooms.value = []
   reachablePositions.value = []
   savedNotes.value = null

--- a/frontend/src/components/GameBoard.vue
+++ b/frontend/src/components/GameBoard.vue
@@ -143,6 +143,12 @@
               @click="doShowCard(card)"
             ><span class="card-icon">{{ cardIcon(card) }}</span> {{ card }}</button>
           </div>
+          <div v-if="showCardCountdown !== null && matchingCards.length === 1" class="auto-show-card-timer">
+            <div class="timer-bar">
+              <div class="timer-bar-fill" :style="{ width: (showCardCountdown / (props.autoShowCardTimer?.seconds || 7)) * 100 + '%' }"></div>
+            </div>
+            <span class="timer-text">Auto-showing in {{ showCardCountdown }}s</span>
+          </div>
         </section>
 
         <!-- Actions -->
@@ -311,6 +317,7 @@ const props = defineProps({
   chatMessages: { type: Array, default: () => [] },
   isObserver: { type: Boolean, default: false },
   autoEndTimer: { type: Object, default: null },
+  autoShowCardTimer: { type: Object, default: null },
   reachableRooms: { type: Array, default: () => [] },
   reachablePositions: { type: Array, default: () => [] },
   savedNotes: { type: Object, default: null },
@@ -360,7 +367,40 @@ watch(
   { immediate: true }
 )
 
-onUnmounted(() => clearCountdown())
+// Auto-show-card timer countdown
+const showCardCountdown = ref(null)
+let showCardCountdownInterval = null
+
+function clearShowCardCountdown() {
+  if (showCardCountdownInterval) {
+    clearInterval(showCardCountdownInterval)
+    showCardCountdownInterval = null
+  }
+  showCardCountdown.value = null
+}
+
+watch(
+  () => props.autoShowCardTimer,
+  (timer) => {
+    clearShowCardCountdown()
+    if (timer && timer.seconds > 0) {
+      const updateCountdown = () => {
+        const elapsed = (Date.now() - timer.startedAt) / 1000
+        const remaining = Math.max(0, Math.ceil(timer.seconds - elapsed))
+        showCardCountdown.value = remaining
+        if (remaining <= 0) clearShowCardCountdown()
+      }
+      updateCountdown()
+      showCardCountdownInterval = setInterval(updateCountdown, 1000)
+    }
+  },
+  { immediate: true }
+)
+
+onUnmounted(() => {
+  clearCountdown()
+  clearShowCardCountdown()
+})
 
 const timerForMe = computed(() => countdown.value !== null && props.autoEndTimer?.playerId === props.playerId)
 
@@ -1120,6 +1160,10 @@ watch(
 
 .end-turn-btn:hover {
   background: #229954;
+}
+
+.auto-show-card-timer {
+  margin-top: 0.6rem;
 }
 
 .auto-end-timer {


### PR DESCRIPTION
## Summary
This PR adds an automatic card-showing feature that triggers when a human player has exactly one matching card to show during a suggestion. After 7 seconds of inactivity, the card is automatically shown, improving game flow for human players.

## Key Changes
- **Backend (`main.py`)**:
  - Added `_auto_show_card_timers` dictionary to track pending auto-show timers per game
  - Implemented `_auto_show_card_task()` coroutine that waits 7 seconds then auto-executes `ShowCardAction` if conditions are met
  - Implemented `_maybe_start_auto_show_card_timer()` to initiate the timer only for human players with exactly one matching card
  - Implemented `_cancel_auto_show_card_timer()` to cancel pending timers
  - Integrated timer cancellation into `_execute_action()` so any player action cancels the auto-show timer
  - Added cleanup of auto-show timers in the FastAPI lifespan shutdown handler
  - Timer only triggers if game is still in "playing" status and the same player still has a pending show card request

- **Backend (`models.py`)**:
  - Added `AutoShowCardTimerMessage` WebSocket message type to notify clients when auto-show timer starts

- **Frontend (`GameBoard.vue`)**:
  - Added `showCardCountdown` ref to track remaining seconds for display
  - Added countdown timer UI that displays "Auto-showing in Xs" with a visual progress bar
  - Implemented `clearShowCardCountdown()` and watch handler for `autoShowCardTimer` prop
  - Timer only displays when player has exactly one matching card
  - Cleanup of countdown interval on component unmount

- **Frontend (`App.vue`)**:
  - Added `autoShowCardTimer` ref to track timer state
  - Added message handler for `auto_show_card_timer` message type
  - Clear auto-show timer when card is shown (both private and public cases)
  - Clear auto-show timer on turn end and game end
  - Reset auto-show timer state on game reset

## Implementation Details
- The auto-show timer only applies to human players (not agents/LLM agents/wanderers)
- Timer is only started when a player has exactly one matching card, eliminating ambiguity
- Timer is cancelled if the player takes any action or if game state changes
- Frontend countdown is calculated client-side from `startedAt` timestamp for accurate display
- Visual progress bar shows remaining time as a percentage of total duration

https://claude.ai/code/session_01PU2BQLVJ1wHp93AVZooPix