### PR TITLE
Fix Study door direction from east to south

### DIFF
--- a/backend/app/board.py
+++ b/backend/app/board.py
@@ -103,7 +103,7 @@ ROOM_KEYS = {
 # Doors: (row, col) ON the room perimeter (inset 1 from hallway)
 # Each connects to the room node + adjacent hallway square outside the room
 DOORS = {
-    # Study (0,0)-(3,6): south-east corner
+    # Study (0,0)-(3,6): south side
     (3, 6): Room.STUDY,
     # Hall (1,9)-(6,14): 2 south, 1 west
     (6, 11): Room.HALL,

--- a/frontend/src/components/BoardMap.vue
+++ b/frontend/src/components/BoardMap.vue
@@ -95,7 +95,7 @@ const DOORS = {
 }
 
 const DOOR_DIRECTIONS = {
-  '3,6': 'east',      // Study → hallway right
+  '3,6': 'south',     // Study → hallway below
   '4,9': 'west',      // Hall → hallway left
   '6,11': 'south',    // Hall → hallway below
   '6,12': 'south',    // Hall → hallway below


### PR DESCRIPTION
## Summary
Corrected the door direction for the Study room from east to south to accurately reflect the game board layout.

## Changes
- **backend/app/board.py**: Updated the comment for the Study room door location from "south-east corner" to "south side" to clarify the correct door position
- **frontend/src/components/BoardMap.vue**: Changed the `DOOR_DIRECTIONS` mapping for the Study door at position (3,6) from 'east' to 'south', with updated comment explaining the door leads to the hallway below

## Details
The Study room door at coordinates (3,6) was incorrectly marked as opening to the east. This has been corrected to south, which aligns with the actual board layout where the door connects to the hallway below the room. Both backend and frontend have been updated to maintain consistency.

https://claude.ai/code/session_0184YqvoVcMEETZbPwoSt68A