### PR TITLE
Let auto-end timer handle LLM agents with limited actions

### DIFF
--- a/backend/agent_runner.py
+++ b/backend/agent_runner.py
@@ -286,6 +286,19 @@ class AgentRunner:
         if game_state.status != "playing":
             return
 
+        # LLM agents with only accuse+end_turn: let the backend's auto-end
+        # timer handle it instead of immediately deciding.
+        if agent.agent_type == "llm":
+            actions = set(player_state.available_actions)
+            if actions == {"accuse", "end_turn"}:
+                logger.info(
+                    "LLM agent %s in game %s has only accuse+end_turn — "
+                    "deferring to auto-end timer",
+                    player_id,
+                    game_id,
+                )
+                return
+
         try:
             action = await agent.decide_action(game_state, player_state)
         except Exception:

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -236,7 +236,8 @@ async def _auto_end_turn_task(game_id: str, player_id: str, turn_number: int):
 async def _maybe_start_auto_end_timer(game_id: str):
     """Check if the current player should get an auto-end-turn timer.
 
-    Starts a timer if the player is human and their only actions are accuse + end_turn.
+    Starts a timer if the player is human or LLM agent and their only actions
+    are accuse + end_turn.
     """
     game = ClueGame(game_id, redis_client)
     state = await game.get_state()
@@ -244,9 +245,9 @@ async def _maybe_start_auto_end_timer(game_id: str):
         return
 
     pid = state.whose_turn
-    # Only apply to human players
+    # Apply to human players and LLM agents (not random agents or wanderers)
     player = next((p for p in state.players if p.id == pid), None)
-    if not player or player.type in _AGENT_PLAYER_TYPES:
+    if not player or player.type in {"agent", "wanderer"}:
         return
 
     actions = set(game.get_available_actions(pid, state))
@@ -823,6 +824,16 @@ async def _run_agent_loop(game_id: str):
                     continue
 
                 agent = agents[pid]
+
+                # LLM agents with only accuse+end_turn: let the auto-end
+                # timer handle it instead of immediately deciding (gives
+                # human observers a visible countdown).
+                if agent.agent_type == "llm":
+                    actions = set(game.get_available_actions(pid, state))
+                    if actions == {"accuse", "end_turn"}:
+                        await asyncio.sleep(0.5)
+                        continue
+
                 player_state = await game.get_player_state(pid)
                 action = await agent.decide_action(state, player_state)
 


### PR DESCRIPTION
## Summary
This change improves the UX for human observers by deferring action decisions for LLM agents when they only have `accuse` and `end_turn` available. Instead of immediately deciding, the agent now yields to the backend's auto-end timer, which provides a visible countdown for observers.

## Key Changes
- **Updated auto-end timer eligibility**: Modified `_maybe_start_auto_end_timer()` to include LLM agents (in addition to human players), while excluding random agents and wanderers
- **Agent loop deferral**: Added logic in `_run_agent_loop()` to skip immediate decision-making for LLM agents when only `accuse` and `end_turn` are available, allowing the auto-end timer to take over
- **Agent runner deferral**: Added similar deferral logic in `agent_runner.py`'s `_handle_your_turn()` to prevent LLM agents from immediately deciding when limited to these two actions

## Implementation Details
- LLM agents now check if their available actions are exactly `{"accuse", "end_turn"}` and defer to the auto-end timer if so
- The deferral includes a small sleep (0.5s) in the agent loop to prevent busy-waiting
- Logging added to track when LLM agents defer to the auto-end timer
- Random agents and wanderers are explicitly excluded from the auto-end timer to maintain existing behavior

https://claude.ai/code/session_01DGahtLxgB5f4qfhv3dpSnm