### PR TITLE
Use two dice (2d6) instead of one for movement rolls

### DIFF
--- a/backend/app/games/clue/agents.py
+++ b/backend/app/games/clue/agents.py
@@ -984,7 +984,7 @@ class RandomAgent(BaseAgent):
         if "move" in available:
             player_pos = game_state.player_positions.get(player_id)
             my_room = current_room.get(player_id)
-            dice_value = game_state.last_roll[0] if game_state.last_roll else 12
+            dice_value = sum(game_state.last_roll) if game_state.last_roll else 12
 
             # Compute which rooms are reachable within the dice roll
             room_dists = _compute_room_distances(my_room, player_pos)
@@ -1692,7 +1692,7 @@ class LLMAgent(BaseAgent):
             f"- Unknown weapons (could be solution): {unknown_weapons}",
             f"- Unknown rooms (could be solution): {unknown_rooms}",
             f"- Your current room: {current_room.get(player_id, 'none')}",
-            f"- Dice roll: {game_state.last_roll[0] if game_state.last_roll else 'not rolled yet'}",
+            f"- Dice roll: {'+'.join(str(d) for d in game_state.last_roll) + '=' + str(sum(game_state.last_roll)) if game_state.last_roll else 'not rolled yet'}",
             f"- Available actions: {available}",
         ]
 

--- a/backend/app/games/clue/game.py
+++ b/backend/app/games/clue/game.py
@@ -387,8 +387,8 @@ class ClueGame:
 
         return state
 
-    def roll_dice(self) -> int:
-        return random.randint(1, 6)
+    def roll_dice(self) -> tuple[int, int]:
+        return (random.randint(1, 6), random.randint(1, 6))
 
     @staticmethod
     def _get_start_square(player_id: str, state: "GameState"):
@@ -505,8 +505,9 @@ class ClueGame:
         if state.dice_rolled:
             raise ValueError("You already rolled this turn")
 
-        total = self.roll_dice()
-        state.last_roll = [total]
+        die1, die2 = self.roll_dice()
+        total = die1 + die2
+        state.last_roll = [die1, die2]
         state.dice_rolled = True
 
         await self._save_state(state)
@@ -563,7 +564,7 @@ class ClueGame:
         if state.moved:
             raise ValueError("You already moved this turn")
 
-        total = state.last_roll[0] if state.last_roll else 0
+        total = sum(state.last_roll) if state.last_roll else 0
 
         room_name = action.room
         target_pos = action.position

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -402,9 +402,11 @@ async def _execute_action(
                 dice=result.dice,
             )
         else:
+            roll_parts = state.last_roll or []
+            roll_text = f"{result.dice} ({'+'.join(str(d) for d in roll_parts)})" if len(roll_parts) > 1 else str(result.dice)
             await _broadcast_chat(
                 game_id,
-                f"{actor_name} rolled {result.dice}.",
+                f"{actor_name} rolled {roll_text}.",
                 player_id,
             )
         await manager.send_to_player(

--- a/backend/tests/test_game.py
+++ b/backend/tests/test_game.py
@@ -57,7 +57,7 @@ async def _place_player_in_room(game: ClueGame, player_id: str, room: str):
     state.current_room[player_id] = room
     state.dice_rolled = True
     state.moved = True
-    state.last_roll = [6]
+    state.last_roll = [3, 3]
     center = ROOM_CENTERS.get(room)
     if center:
         state.player_positions[player_id] = list(center)
@@ -570,7 +570,7 @@ async def test_roll_then_move(game: ClueGame):
     # Roll dice
     result = await game.process_action(whose_turn, {"type": "roll"})
     assert result.type == "roll"
-    assert result.dice >= 1
+    assert 2 <= result.dice <= 12
 
     # After rolling: move is available, roll and end_turn are not
     state = await game.get_state()

--- a/backend/tests/test_ws_e2e.py
+++ b/backend/tests/test_ws_e2e.py
@@ -165,7 +165,7 @@ async def _place_in_room(redis, game_id: str, player_id: str, room: str):
     state.current_room[player_id] = room
     state.dice_rolled = True
     state.moved = True
-    state.last_roll = [6]
+    state.last_roll = [3, 3]
     center = ROOM_CENTERS.get(room)
     if center:
         state.player_positions[player_id] = list(center)

--- a/frontend/src/App.vue
+++ b/frontend/src/App.vue
@@ -243,7 +243,6 @@ function handleMessage(msg) {
         const positions = { ...(gameState.value.player_positions || {}) }
         if (msg.position) positions[msg.player_id] = msg.position
         const updates = { current_room: rooms, player_positions: positions, moved: true }
-        if (msg.dice) updates.last_roll = [msg.dice]
         gameState.value = { ...gameState.value, ...updates }
       }
       // Clear reachable highlights after movement

--- a/frontend/src/components/GameBoard.vue
+++ b/frontend/src/components/GameBoard.vue
@@ -26,7 +26,7 @@
       <div class="header-right">
         <div v-if="isObserver" class="observer-badge">Observer</div>
         <div v-if="gameState?.last_roll" class="dice-display" title="Last dice roll">
-          <span class="dice">{{ gameState.last_roll[0] }}</span>
+          <span class="dice" v-for="(die, idx) in gameState.last_roll" :key="idx">{{ die }}</span>
         </div>
       </div>
     </header>
@@ -168,7 +168,7 @@
 
           <!-- Move (choose room after rolling) -->
           <div v-if="canMove" class="action-group">
-            <h3>Move (rolled {{ gameState?.last_roll?.[0] }})</h3>
+            <h3>Move (rolled {{ gameState?.last_roll?.reduce((a, b) => a + b, 0) }})</h3>
             <p class="action-hint">
               Click a highlighted room on the board or select below:
               <span v-if="reachableRooms.length" class="reachable-count">{{ reachableRooms.length }} room{{ reachableRooms.length !== 1 ? 's' : '' }} reachable</span>


### PR DESCRIPTION
Modern Clue uses two dice. Updated roll_dice() to return a pair, last_roll now stores both individual die values [die1, die2], and the total (2-12) is used for movement range. Frontend shows both dice in the header and chat messages display the breakdown.

https://claude.ai/code/session_017Lrm9ve3xAwHzGKxmP4q14