### PR TITLE
Add image generation prompts for Clue mansion rooms

### DIFF
--- a/room-prompts.md
+++ b/room-prompts.md
@@ -1,6 +1,10 @@
-# Mansion Room Image Generation Prompts
+# Mansion Image Generation Prompts
 
-Prompts for generating top-down room illustrations for the Clue board game.
+Prompts for generating illustrations for the Clue board game.
+
+---
+
+## Rooms
 
 ---
 
@@ -64,3 +68,51 @@ Prompts for generating top-down room illustrations for the Clue board game.
 **Ratio:** 1:1
 
 > Colored pencil art. Rustic victorian Cluedo mansion — the Kitchen. Top-down view. Warm copper and cream tones. A heavy butcher-block island, cast-iron pots hanging from a ceiling rack, a coal-burning range with a kettle, flour dusted across the counter, a knife block, bundles of dried herbs, a pantry door slightly ajar. Warm gaslight glow on stone floor tiles.
+
+---
+
+## Weapons
+
+Weapon card illustrations. Each depicts the weapon as a central object on a dark surface, styled as evidence photography with a victorian twist.
+
+---
+
+### Candlestick
+**Ratio:** 2:3
+
+> Colored pencil art. Dark victorian noir Cluedo weapon — the Candlestick. A heavy brass candlestick with melted wax dripping down its stem, lying on its side on rumpled velvet. Warm golden and tarnished bronze tones. A single flame still guttering at the wick. Wax spatters on dark wood beneath. Dramatic side-lighting casting a long shadow.
+
+---
+
+### Knife
+**Ratio:** 9:16
+
+> Colored pencil art. Dark victorian noir Cluedo weapon — the Knife. A sharp carving knife with an ivory handle, laid diagonally on a white linen napkin. Cold steel blue and bone-white tones. The blade catches a glint of light along its edge. A single dark stain near the tip. Monogrammed handle. Background of polished dark marble.
+
+---
+
+### Lead Pipe
+**Ratio:** 9:16
+
+> Colored pencil art. Dark victorian noir Cluedo weapon — the Lead Pipe. A heavy dull-grey lead pipe, slightly bent, resting on wet cobblestones. Slate grey and rain-slicked charcoal tones. Beads of condensation along its surface. A gaslight reflection in a nearby puddle. Industrial grime and patina. Fog rolling in at the edges.
+
+---
+
+### Revolver
+**Ratio:** 3:2
+
+> Colored pencil art. Dark victorian noir Cluedo weapon — the Revolver. A snub-nosed six-shot revolver with a pearl grip, resting on a green felt card table. Gunmetal black and mother-of-pearl tones. The cylinder slightly open, one chamber empty. Wisps of smoke. Scattered poker chips and a spent brass casing nearby. Warm lamplight from above.
+
+---
+
+### Rope
+**Ratio:** 1:1
+
+> Colored pencil art. Dark victorian noir Cluedo weapon — the Rope. A coil of thick hemp rope with a knotted loop, draped over a wooden banister post. Rough sisal tan and dark oak tones. Frayed fibers catching the light. The knot tied in a precise hangman's style. Shadows of staircase railings across the wall. Dusty, forgotten attic atmosphere.
+
+---
+
+### Wrench
+**Ratio:** 4:5
+
+> Colored pencil art. Dark victorian noir Cluedo weapon — the Wrench. A heavy iron pipe wrench with a rust-pitted jaw, resting on a workbench. Deep iron-oxide red and soot-black tones. Oil stains on the wooden bench surface. A torn work glove beside it. Background of brick wall with mounted gas pipes. Harsh overhead workshop light casting hard shadows.

--- a/room-prompts.md
+++ b/room-prompts.md
@@ -1,0 +1,66 @@
+# Mansion Room Image Generation Prompts
+
+Prompts for generating top-down room illustrations for the Clue board game.
+
+---
+
+### Study
+**Ratio:** 16:9
+
+> Colored pencil art. Dark victorian noir of a Cluedo mansion — the Study. Top-down view. Deep midnight blue and mahogany tones. A heavy oak desk strewn with papers and an inkwell, floor-to-ceiling bookshelves, a globe in the corner, a green banker's lamp casting a small circle of light. Persian rug over dark hardwood. Secret passage trapdoor barely visible beneath the rug.
+
+---
+
+### Hall
+**Ratio:** 1:1
+
+> Colored pencil art. Grand victorian Cluedo mansion — the Hall. Top-down view. Warm amber and ivory tones. Black-and-white checkerboard marble floor, a sweeping staircase banister visible at the edge, ornate chandelier shadow cast from above, a tall grandfather clock, coat rack with a top hat and cane. Candlelight sconces on wallpapered walls.
+
+---
+
+### Lounge
+**Ratio:** 5:4
+
+> Colored pencil art. Moody victorian Cluedo mansion — the Lounge. Top-down view. Rich crimson and gold tones. Tufted velvet chaise longue, a crackling fireplace with marble mantel, crystal decanter and glasses on a side table, thick burgundy drapes, an animal-skin rug, scattered playing cards. Cigarette smoke curling upward.
+
+---
+
+### Library
+**Ratio:** 3:2
+
+> Colored pencil art. Atmospheric victorian Cluedo mansion — the Library. Top-down view. Forest green and aged leather tones. Towering shelves packed with leather-bound volumes, a rolling ladder against one wall, a reading chair with an open book face-down on the armrest, a brass telescope near the window, scattered notes and a magnifying glass on a side table.
+
+---
+
+### Billiard Room
+**Ratio:** 5:4
+
+> Colored pencil art. Smoky victorian Cluedo mansion — the Billiard Room. Top-down view. Emerald green and polished walnut tones. A full-size billiard table with balls mid-game, cue rack on the wall, low-hanging tiffany lamp over the table, leather wingback chairs, a whiskey cart, mounted trophy heads faintly visible on wood-paneled walls.
+
+---
+
+### Dining Room
+**Ratio:** 1:1
+
+> Colored pencil art. Opulent victorian Cluedo mansion — the Dining Room. Top-down view. Deep plum and silver tones. A long mahogany dining table set for six with fine china and candelabras, high-backed chairs, a sideboard with a silver tureen, wine bottles, and a carving knife. Heavy damask curtains. Spilled red wine on the white tablecloth.
+
+---
+
+### Conservatory
+**Ratio:** 5:4
+
+> Colored pencil art. Lush victorian Cluedo mansion — the Conservatory. Top-down view. Warm sage green and terracotta tones. Glass-paned ceiling letting in pale moonlight, potted palms and exotic ferns, a wrought-iron garden bench, stone tile floor with moss in the cracks, a watering can, scattered gardening tools, and a vine creeping along the window frame.
+
+---
+
+### Ballroom
+**Ratio:** 1:1
+
+> Colored pencil art. Elegant victorian Cluedo mansion — the Ballroom. Top-down view. Lavender and champagne gold tones. Vast polished parquet dance floor with geometric inlay pattern, a grand piano in the corner, enormous crystal chandelier reflection on the floor, floor-length mirrors on the walls, velvet rope barriers, a single dropped silk glove.
+
+---
+
+### Kitchen
+**Ratio:** 1:1
+
+> Colored pencil art. Rustic victorian Cluedo mansion — the Kitchen. Top-down view. Warm copper and cream tones. A heavy butcher-block island, cast-iron pots hanging from a ceiling rack, a coal-burning range with a kettle, flour dusted across the counter, a knife block, bundles of dried herbs, a pantry door slightly ajar. Warm gaslight glow on stone floor tiles.


### PR DESCRIPTION
## Summary
Added a comprehensive collection of AI image generation prompts for creating top-down room illustrations of the Clue board game mansion. These prompts provide detailed specifications for generating artwork of all nine rooms with consistent Victorian aesthetic and atmospheric details.

## Changes
- Created `room-prompts.md` with curated prompts for nine mansion rooms:
  - Study, Hall, Lounge, Library, Billiard Room, Dining Room, Conservatory, Ballroom, and Kitchen
- Each prompt includes:
  - Specified aspect ratio for the generated image
  - Detailed visual description emphasizing Victorian noir/gothic atmosphere
  - Specific color palettes tailored to each room's character
  - Room-specific furniture, décor, and atmospheric elements
  - Consistent art style direction (colored pencil art, top-down view)

## Implementation Details
- Prompts are designed for consistency across all rooms while maintaining unique character for each space
- Aspect ratios vary (16:9, 1:1, 5:4, 3:2) to accommodate different room layouts and compositions
- Each prompt balances atmospheric mood with specific gameplay-relevant details (e.g., weapons, evidence locations)
- Markdown formatting provides clear organization and easy reference for image generation workflows

https://claude.ai/code/session_018q6QAvCgiFWzrccCS3d3ZA