### PR TITLE
Reduce max-width of clue app container from 1280px to 1080px

### DIFF
--- a/frontend/src/App.vue
+++ b/frontend/src/App.vue
@@ -745,7 +745,7 @@ body {
   min-height: 100vh;
 }
 #clue-app {
-  max-width: 1280px;
+  max-width: 1080px;
   margin: 0 auto;
   padding: 0.75rem;
 }


### PR DESCRIPTION
## Summary
Adjusted the maximum width constraint of the main application container to improve layout and readability.

## Changes
- Reduced `#clue-app` max-width from 1280px to 1080px in App.vue styles

## Details
This change narrows the maximum width of the application container, which will result in a more compact layout on larger displays. This adjustment may improve content readability and visual hierarchy by constraining the content width to a narrower viewport.

https://claude.ai/code/session_01GEzWVrEFSe75QD4WCwmYxD