### PR TITLE
Fix board container box model with content-box sizing

### DIFF
--- a/frontend/src/components/BoardMap.vue
+++ b/frontend/src/components/BoardMap.vue
@@ -453,6 +453,7 @@ function tokenStyle(token) {
 
 .board-container {
   position: relative;
+  box-sizing: content-box;
   width: 100%;
   max-width: 690px;
   margin: 0 auto;


### PR DESCRIPTION
## Summary
Updated the `.board-container` CSS to use `box-sizing: content-box` to ensure proper layout calculations and prevent padding/border from affecting the container's width.

## Changes
- Added `box-sizing: content-box` to `.board-container` style rule in BoardMap.vue

## Details
This change explicitly sets the box-sizing model for the board container to `content-box`, which ensures that the `width: 100%` and `max-width: 690px` properties are calculated based on content dimensions only, excluding any padding or borders. This prevents unintended layout shifts or overflow issues that could occur if the browser's default box-sizing model differs from the intended behavior.

https://claude.ai/code/session_01N6LZVTJTvMCPDeezvv6TRE