### PR TITLE
Clear was_moved_by_suggestion flag when player acts, not just at end_…

### DIFF
--- a/backend/app/games/clue/game.py
+++ b/backend/app/games/clue/game.py
@@ -508,6 +508,9 @@ class ClueGame:
         total = die1 + die2
         state.last_roll = [die1, die2]
         state.dice_rolled = True
+        # Rolling means the player declined the free suggest from being
+        # moved by a suggestion, so clear the flag.
+        state.was_moved_by_suggestion.pop(player_id, None)
 
         await self._save_state(state)
         await self._append_log(
@@ -531,6 +534,9 @@ class ClueGame:
         dest_room = SECRET_PASSAGE_MAP[current_room]
         state.current_room[player_id] = dest_room
         state.moved = True
+        # Using a secret passage means the player declined the free suggest
+        # from being moved by a suggestion, so clear the flag.
+        state.was_moved_by_suggestion.pop(player_id, None)
         position: list[int] | None = None
         center = ROOM_CENTERS.get(dest_room)
         if center:
@@ -722,6 +728,10 @@ class ClueGame:
                 # so they can suggest from it on their next turn without rolling.
                 state.was_moved_by_suggestion[moved_suspect_player] = True
                 break
+
+        # If this player was using their free suggest (from being moved by
+        # a suggestion), clear the flag now that it's been consumed.
+        state.was_moved_by_suggestion.pop(player_id, None)
 
         suggestion_entry = Suggestion(
             suspect=suspect,

--- a/backend/tests/test_game.py
+++ b/backend/tests/test_game.py
@@ -884,6 +884,103 @@ async def test_flag_cleared_after_turn_ends(game: ClueGame):
 
 
 @pytest.mark.asyncio
+async def test_flag_cleared_on_roll(game: ClueGame):
+    """The was_moved_by_suggestion flag is cleared as soon as the player rolls."""
+    await _add_two_players(game)
+    state = await game.start()
+
+    whose_turn = state.whose_turn
+    other_id = "P2" if whose_turn == "P1" else "P1"
+    other_char = next(p.character for p in state.players if p.id == other_id)
+
+    room = ROOMS[0]
+    await _place_player_in_room(game, whose_turn, room)
+
+    result = await game.process_action(
+        whose_turn,
+        {"type": "suggest", "suspect": other_char, "weapon": WEAPONS[0], "room": room},
+    )
+    if result.pending_show_by:
+        st = await game._load_state()
+        matching = st.pending_show_card.matching_cards
+        await game.process_action(
+            result.pending_show_by, {"type": "show_card", "card": matching[0]}
+        )
+
+    await game.process_action(whose_turn, {"type": "end_turn"})
+
+    # Advance to other_id's turn
+    state = await game.get_state()
+    while state.whose_turn != other_id:
+        wt = state.whose_turn
+        await _advance_turn(game, wt)
+        state = await game.get_state()
+
+    # Flag is set before rolling
+    assert state.was_moved_by_suggestion.get(other_id) is True
+
+    # Roll — the player declines the free suggest
+    await game.process_action(other_id, {"type": "roll"})
+    state = await game.get_state()
+
+    # Flag should be cleared immediately after rolling
+    assert state.was_moved_by_suggestion.get(other_id) is None
+
+
+@pytest.mark.asyncio
+async def test_flag_cleared_on_free_suggest(game: ClueGame):
+    """The was_moved_by_suggestion flag is cleared when the player uses the free suggest."""
+    await _add_two_players(game)
+    state = await game.start()
+
+    whose_turn = state.whose_turn
+    other_id = "P2" if whose_turn == "P1" else "P1"
+    other_char = next(p.character for p in state.players if p.id == other_id)
+
+    room = ROOMS[0]
+    await _place_player_in_room(game, whose_turn, room)
+
+    result = await game.process_action(
+        whose_turn,
+        {"type": "suggest", "suspect": other_char, "weapon": WEAPONS[0], "room": room},
+    )
+    if result.pending_show_by:
+        st = await game._load_state()
+        matching = st.pending_show_card.matching_cards
+        await game.process_action(
+            result.pending_show_by, {"type": "show_card", "card": matching[0]}
+        )
+
+    await game.process_action(whose_turn, {"type": "end_turn"})
+
+    # Advance to other_id's turn
+    state = await game.get_state()
+    while state.whose_turn != other_id:
+        wt = state.whose_turn
+        await _advance_turn(game, wt)
+        state = await game.get_state()
+
+    # Flag is set before suggesting
+    assert state.was_moved_by_suggestion.get(other_id) is True
+
+    # Use the free suggest
+    result = await game.process_action(
+        other_id,
+        {"type": "suggest", "suspect": SUSPECTS[0], "weapon": WEAPONS[0], "room": room},
+    )
+    if result.pending_show_by:
+        st = await game._load_state()
+        matching = st.pending_show_card.matching_cards
+        await game.process_action(
+            result.pending_show_by, {"type": "show_card", "card": matching[0]}
+        )
+
+    # Flag should be cleared after using the free suggest
+    state = await game.get_state()
+    assert state.was_moved_by_suggestion.get(other_id) is None
+
+
+@pytest.mark.asyncio
 async def test_no_free_suggest_without_being_moved(game: ClueGame):
     """A player NOT moved by suggestion should not get suggest before rolling."""
     await _add_two_players(game)


### PR DESCRIPTION
…turn

The flag was only cleared in _handle_end_turn, meaning it persisted through roll/move actions even though it was no longer relevant. Now clear it when the player rolls (declining free suggest), uses a secret passage, or uses the free suggest itself. The end_turn pop remains as a safety net.

https://claude.ai/code/session_014BY8ey6jjcdxavwPRMZSta