### PR TITLE
Fix board bottom row getting clipped by half

### DIFF
--- a/frontend/src/components/BoardMap.vue
+++ b/frontend/src/components/BoardMap.vue
@@ -428,8 +428,8 @@ function tokenStyle(token) {
   display: grid;
   grid-template-columns: repeat(24, 1fr);
   grid-template-rows: repeat(25, 1fr);
-  width: 100%;
-  height: 100%;
+  position: absolute;
+  inset: 0;
   gap: 0;
   background: #1a1510;
   background-image: linear-gradient(to right, #15110c 1px, transparent 1px),


### PR DESCRIPTION
## Summary
- Fix the bottom row of the Clue board being cut off by half due to sub-pixel rounding with `overflow: hidden`
- Change `.board-grid` from `width/height: 100%` to `position: absolute; inset: 0` so it fills the container exactly

## Test plan
- [ ] Verify bottom row of board is fully visible on desktop
- [ ] Verify board renders correctly on mobile/small screens
- [ ] Verify player tokens on bottom row (starting positions) are fully visible

🤖 Generated with [Claude Code](https://claude.com/claude-code)