### PR TITLE
Add poker bot personalities (Rock, Maniac, Shark, Fish, Nit, LAG)

### DIFF
--- a/backend/app/games/holdem/__init__.py
+++ b/backend/app/games/holdem/__init__.py
@@ -1,7 +1,10 @@
 """Texas Hold'em poker game package."""
 
-from .agents import HoldemAgent
+from .agents import HoldemAgent, PERSONALITIES, PERSONALITY_NAMES, get_personality
 from .game import HoldemGame
 from .hand_eval import evaluate_hand, hand_name
 
-__all__ = ["HoldemAgent", "HoldemGame", "evaluate_hand", "hand_name"]
+__all__ = [
+    "HoldemAgent", "HoldemGame", "evaluate_hand", "hand_name",
+    "PERSONALITIES", "PERSONALITY_NAMES", "get_personality",
+]

--- a/backend/app/games/holdem/agents.py
+++ b/backend/app/games/holdem/agents.py
@@ -29,6 +29,67 @@ logger = logging.getLogger(__name__)
 
 
 # ---------------------------------------------------------------------------
+# Personality presets — classic poker archetypes
+# ---------------------------------------------------------------------------
+
+PERSONALITIES: dict[str, dict] = {
+    "Rock": {
+        "aggression": 0.15,
+        "tightness": 0.75,
+        "bluff_frequency": 0.03,
+        "slowplay_frequency": 0.05,
+        "chat_frequency": 0.15,
+    },
+    "Maniac": {
+        "aggression": 0.90,
+        "tightness": 0.10,
+        "bluff_frequency": 0.45,
+        "slowplay_frequency": 0.0,
+        "chat_frequency": 0.60,
+    },
+    "Shark": {
+        "aggression": 0.70,
+        "tightness": 0.55,
+        "bluff_frequency": 0.18,
+        "slowplay_frequency": 0.20,
+        "chat_frequency": 0.25,
+    },
+    "Fish": {
+        "aggression": 0.25,
+        "tightness": 0.20,
+        "bluff_frequency": 0.05,
+        "slowplay_frequency": 0.0,
+        "chat_frequency": 0.40,
+    },
+    "Nit": {
+        "aggression": 0.10,
+        "tightness": 0.90,
+        "bluff_frequency": 0.01,
+        "slowplay_frequency": 0.05,
+        "chat_frequency": 0.10,
+    },
+    "LAG": {
+        "aggression": 0.80,
+        "tightness": 0.25,
+        "bluff_frequency": 0.30,
+        "slowplay_frequency": 0.10,
+        "chat_frequency": 0.35,
+    },
+}
+
+PERSONALITY_NAMES = list(PERSONALITIES.keys())
+
+
+def get_personality(name: str | None = None) -> tuple[str, dict]:
+    """Return (personality_name, config_dict). Picks randomly if name is None."""
+    if name and name in PERSONALITIES:
+        return name, dict(PERSONALITIES[name])
+    return random.choice(PERSONALITY_NAMES), dict(
+        PERSONALITIES[random.choice(PERSONALITY_NAMES)]
+    )
+
+
+# ---------------------------------------------------------------------------
 # Preflop hand strength — simple lookup for starting hand categories
 # ---------------------------------------------------------------------------
 
@@ -156,19 +217,22 @@ class HoldemAgent:
         bluff_frequency: float = 0.15,
         slowplay_frequency: float = 0.1,
         chat_frequency: float = 0.3,
+        personality: str | None = None,
     ):
         self.player_id = player_id
         self.name = name
+        self.personality = personality
         self.aggression = max(0.0, min(1.0, aggression))
         self.tightness = max(0.0, min(1.0, tightness))
         self.bluff_frequency = max(0.0, min(1.0, bluff_frequency))
         self.slowplay_frequency = max(0.0, min(1.0, slowplay_frequency))
         self.chat_frequency = max(0.0, min(1.0, chat_frequency))
         logger.info(
-            "[holdem_agent] Created agent %s (%s) aggression=%.2f tightness=%.2f "
-            "bluff=%.2f slowplay=%.2f chat=%.2f",
+            "[holdem_agent] Created agent %s (%s) personality=%s aggression=%.2f "
+            "tightness=%.2f bluff=%.2f slowplay=%.2f chat=%.2f",
             player_id,
             name,
+            personality or "default",
             self.aggression,
             self.tightness,
             self.bluff_frequency,
@@ -347,42 +411,80 @@ class HoldemAgent:
         return amount
 
     def generate_chat(self, action_type: str, **kwargs) -> str | None:
-        """Occasionally generate a chat message after an action."""
+        """Occasionally generate a personality-flavored chat message."""
         if random.random() > self.chat_frequency:
             return None
 
-        messages = {
-            "fold": [
-                "Not my hand.",
-                "I'll sit this one out.",
-                "Too rich for my blood.",
-            ],
-            "check": [
-                "Check.",
-                "I'll check here.",
-                "Let's see what comes.",
-            ],
-            "call": [
-                "I'll call.",
-                "I'm in.",
-                "Let's see the next card.",
-            ],
-            "bet": [
-                "Putting some chips out there.",
-                "Let's make it interesting.",
-                "I like what I see.",
-            ],
-            "raise": [
-                "Raising it up.",
-                "Let's go bigger.",
-                "I think I've got something here.",
-            ],
-            "all_in": [
-                "All in!",
-                "Going for it all!",
-                "Let's gamble!",
-            ],
-        }
+        options = _PERSONALITY_CHAT.get(
+            self.personality, _DEFAULT_CHAT
+        ).get(action_type)
 
-        options = messages.get(action_type, ["Hmm..."])
+        if not options:
+            options = _DEFAULT_CHAT.get(action_type, ["Hmm..."])
+
         return random.choice(options)
+
+
+# ---------------------------------------------------------------------------
+# Per-personality chat lines
+# ---------------------------------------------------------------------------
+
+_DEFAULT_CHAT: dict[str, list[str]] = {
+    "fold": ["Not my hand.", "I'll sit this one out.", "Too rich for my blood."],
+    "check": ["Check.", "I'll check here.", "Let's see what comes."],
+    "call": ["I'll call.", "I'm in.", "Let's see the next card."],
+    "bet": ["Putting some chips out there.", "Let's make it interesting.", "I like what I see."],
+    "raise": ["Raising it up.", "Let's go bigger.", "I think I've got something here."],
+    "all_in": ["All in!", "Going for it all!", "Let's gamble!"],
+}
+
+_PERSONALITY_CHAT: dict[str, dict[str, list[str]]] = {
+    "Rock": {
+        "fold": ["I'll wait for a better spot.", "Patience pays.", "Not worth the risk."],
+        "check": ["Check.", "No need to rush."],
+        "call": ["I'll see it.", "Alright, I'll call."],
+        "bet": ["I've got something here.", "Time to value bet."],
+        "raise": ["Premium hand. Raising.", "You're going to pay for that."],
+        "all_in": ["I've got the goods. All in.", "Nuts. All in."],
+    },
+    "Maniac": {
+        "fold": ["Fine, FINE. I fold.", "You got lucky.", "Whatever."],
+        "check": ["Check… for now.", "I'm setting a trap!"],
+        "call": ["Yeah yeah, I call.", "Can't scare me off."],
+        "bet": ["BOOM! Bet!", "Let's gooo!", "Chips go in!"],
+        "raise": ["RAISE! Let's party!", "You can't handle this!", "Scared yet?"],
+        "all_in": ["ALL IN BABY!", "YOLO!", "Ship it! ALL IN!"],
+    },
+    "Shark": {
+        "fold": ["Not this time.", "I'll pick a better spot."],
+        "check": ["Check.", "Let's see the next card."],
+        "call": ["Pot odds say call.", "I'll call."],
+        "bet": ["Betting for value.", "Let's build the pot."],
+        "raise": ["Raising.", "I like my equity here."],
+        "all_in": ["All in. Your move.", "I'm putting you to the test."],
+    },
+    "Fish": {
+        "fold": ["Aww, okay.", "I guess I'll fold…", "This game is hard."],
+        "check": ["Check!", "I'll check, I guess?"],
+        "call": ["Ooh, I'll call!", "I wanna see!", "Sounds fun, call!"],
+        "bet": ["Let me try betting!", "I'll put some in.", "Bet!"],
+        "raise": ["Raise! Is that right?", "More chips!", "I'm raising!"],
+        "all_in": ["All in! Wheee!", "I'm going for it!", "All my chips!"],
+    },
+    "Nit": {
+        "fold": ["Fold.", "Easy fold.", "Not even close."],
+        "check": ["Check.", "Checking."],
+        "call": ["…Fine. Call.", "I suppose I'll call."],
+        "bet": ["Betting.", "I have a strong hand."],
+        "raise": ["Raise. I have it.", "Big hand. Raising."],
+        "all_in": ["I have the nuts. All in.", "All in."],
+    },
+    "LAG": {
+        "fold": ["Alright, you got me.", "Nice hand.", "I'll let this one go."],
+        "check": ["Check. For now.", "Trapping…"],
+        "call": ["Call. Let's dance.", "I'm not going anywhere."],
+        "bet": ["Bet. Put up or shut up.", "Applying pressure.", "Let's go."],
+        "raise": ["Raise! Keep up.", "Re-raise. Your move.", "Putting you to the test."],
+        "all_in": ["All in. Do you have it?", "Shove. Call me if you dare."],
+    },
+}

--- a/backend/app/games/holdem/agents.py
+++ b/backend/app/games/holdem/agents.py
@@ -84,11 +84,8 @@ def get_personality(name: str | None = None) -> tuple[str, dict]:
     """Return (personality_name, config_dict). Picks randomly if name is None."""
     if name and name in PERSONALITIES:
         return name, dict(PERSONALITIES[name])
-    return random.choice(PERSONALITY_NAMES), dict(
-        PERSONALITIES[random.choice(PERSONALITY_NAMES)]
-    )
-
-
+    chosen_name = random.choice(PERSONALITY_NAMES)
+    return chosen_name, dict(PERSONALITIES[chosen_name])
 # ---------------------------------------------------------------------------
 # Preflop hand strength — simple lookup for starting hand categories
 # ---------------------------------------------------------------------------

--- a/backend/app/games/holdem/models.py
+++ b/backend/app/games/holdem/models.py
@@ -357,11 +357,12 @@ class HoldemChatMessagesResponse(BaseModel):
 
 class HoldemAddAgentRequest(BaseModel):
     name: str = ""
-    aggression: float = 0.5
-    tightness: float = 0.5
-    bluff_frequency: float = 0.15
-    slowplay_frequency: float = 0.1
-    chat_frequency: float = 0.3
+    personality: str = ""
+    aggression: float | None = None
+    tightness: float | None = None
+    bluff_frequency: float | None = None
+    slowplay_frequency: float | None = None
+    chat_frequency: float | None = None
 
 
 class OkResponse(BaseModel):

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -80,7 +80,7 @@ from .games.clue.models import (
     YourTurnMessage,
 )
 from .ws_manager import ConnectionManager
-from .games.holdem.agents import HoldemAgent, get_personality, PERSONALITY_NAMES
+from .games.holdem.agents import HoldemAgent, get_personality
 from .games.holdem.game import HoldemGame
 from .games.holdem.models import (
     HoldemActionMessage,

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -80,7 +80,7 @@ from .games.clue.models import (
     YourTurnMessage,
 )
 from .ws_manager import ConnectionManager
-from .games.holdem.agents import HoldemAgent
+from .games.holdem.agents import HoldemAgent, get_personality, PERSONALITY_NAMES
 from .games.holdem.game import HoldemGame
 from .games.holdem.models import (
     HoldemActionMessage,
@@ -1697,6 +1697,7 @@ async def holdem_start_game(game_id: str):
                 bluff_frequency=config.get("bluff_frequency", 0.15),
                 slowplay_frequency=config.get("slowplay_frequency", 0.1),
                 chat_frequency=config.get("chat_frequency", 0.3),
+                personality=config.get("personality"),
             )
             logger.info(
                 "Created holdem agent for player %s (%s) in game %s",
@@ -1992,11 +1993,18 @@ async def holdem_add_agent(game_id: str, req: HoldemAddAgentRequest | None = Non
     if state is None:
         raise HTTPException(status_code=404, detail="Game not found")
 
-    aggression = req.aggression if req else 0.5
-    tightness = req.tightness if req else 0.5
-    bluff_frequency = req.bluff_frequency if req else 0.15
-    slowplay_frequency = req.slowplay_frequency if req else 0.1
-    chat_frequency = req.chat_frequency if req else 0.3
+    # Resolve personality — use requested, or pick a random one
+    requested_personality = req.personality if req else ""
+    personality_name, personality_defaults = get_personality(
+        requested_personality or None
+    )
+
+    # Explicit params override personality defaults
+    aggression = req.aggression if (req and req.aggression is not None) else personality_defaults["aggression"]
+    tightness = req.tightness if (req and req.tightness is not None) else personality_defaults["tightness"]
+    bluff_frequency = req.bluff_frequency if (req and req.bluff_frequency is not None) else personality_defaults["bluff_frequency"]
+    slowplay_frequency = req.slowplay_frequency if (req and req.slowplay_frequency is not None) else personality_defaults["slowplay_frequency"]
+    chat_frequency = req.chat_frequency if (req and req.chat_frequency is not None) else personality_defaults["chat_frequency"]
 
     # Pick a name
     taken_names = {p.name for p in state.players}
@@ -2020,6 +2028,7 @@ async def holdem_add_agent(game_id: str, req: HoldemAddAgentRequest | None = Non
     # Store agent config in Redis so it can be used at game start
     import json as _json
     agent_config = {
+        "personality": personality_name,
         "aggression": aggression,
         "tightness": tightness,
         "bluff_frequency": bluff_frequency,
@@ -2037,7 +2046,9 @@ async def holdem_add_agent(game_id: str, req: HoldemAddAgentRequest | None = Non
         game_id,
         HoldemPlayerJoinedMessage(player=player, players=list(state.players)),
     )
-    await _holdem_broadcast_chat(game_id, f"{name} joined the table.")
+    await _holdem_broadcast_chat(
+        game_id, f"{name} joined the table. (Style: {personality_name})"
+    )
 
     return HoldemJoinGameResponse(player_id=player_id, player=player)
 


### PR DESCRIPTION
Each personality is a preset of aggression, tightness, bluff_frequency, slowplay_frequency, and chat_frequency params for HoldemAgent. When adding a bot via the API, a random personality is assigned unless one is specified. Personality-flavored chat messages give each archetype a distinct voice.

https://claude.ai/code/session_01TsHVZmiHb7jG13gJK1yoG5