### PR TITLE
Swap Scarlet and Green starting positions on Clue board

### DIFF
--- a/backend/app/games/clue/board.py
+++ b/backend/app/games/clue/board.py
@@ -135,10 +135,10 @@ DOORS = {
 
 # Start positions (row, col)
 START_POSITIONS = {
-    "Scarlet": (24, 9),  # bottom, between Conservatory & Ballroom
+    "Scarlet": (0, 16),  # top, between Hall & Lounge
     "Mustard": (7, 23),  # right side
     "White": (24, 14),  # bottom, between Ballroom & Kitchen
-    "Green": (0, 16),  # top, between Hall & Lounge
+    "Green": (24, 9),  # bottom, between Conservatory & Ballroom
     "Plum": (5, 0),  # left side, between Study & Library
     "Peacock": (18, 0),  # left side, between Billiard & Conservatory
 }

--- a/frontend/src/components/BoardMap.vue
+++ b/frontend/src/components/BoardMap.vue
@@ -130,10 +130,10 @@ const DOOR_DIRECTIONS = {
 }
 
 const STARTS = {
-  '24,9': 'Scarlet',
+  '0,16': 'Scarlet',
   '7,23': 'Mustard',
   '24,14': 'White',
-  '0,16': 'Green',
+  '24,9': 'Green',
   '5,0': 'Plum',
   '18,0': 'Peacock'
 }


### PR DESCRIPTION
## Summary
This PR swaps the starting positions of the Scarlet and Green characters on the Clue game board to correct their initial placement locations.

## Changes
- **Backend (board.py)**: Updated `START_POSITIONS` dictionary to swap Scarlet and Green coordinates
  - Scarlet: moved from `(24, 9)` (bottom) to `(0, 16)` (top)
  - Green: moved from `(0, 16)` (top) to `(24, 9)` (bottom)

- **Frontend (BoardMap.vue)**: Updated `STARTS` mapping to reflect the new position assignments
  - `'0,16'` now maps to Scarlet (was Green)
  - `'24,9'` now maps to Green (was Scarlet)

## Details
The changes maintain consistency between the backend game logic and frontend board visualization, ensuring both systems agree on which character starts at which position.

https://claude.ai/code/session_01RBAoWFhGrQmSYkDczUUH31