### PR TITLE
refactor: extract shared CSS into components.css

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,6 +95,24 @@ pytest tests/ -v
 
 Tests use `fakeredis` — no running Redis instance needed.
 
+## Debug Scripts
+
+Inspect game state, cards, memory, chat, and agent trace directly from Redis:
+
+```bash
+# List active games
+python scripts/dump_game.py --list-games
+
+# Dump a game with cards + memory
+python scripts/dump_game.py ABC123 --show-cards --show-memory
+
+# Include recent agent trace entries (most recent first)
+python scripts/dump_game.py ABC123 --show-trace
+
+# Limit trace output size
+python scripts/dump_game.py ABC123 --show-trace --trace-limit 100
+```
+
 ## Taking Screenshots
 
 A Playwright-based script captures screenshots of all game states for documentation:

--- a/frontend/src/components/AgentDebugPanel.vue
+++ b/frontend/src/components/AgentDebugPanel.vue
@@ -1,6 +1,6 @@
 <template>
   <div class="agent-debug-panel">
-    <h2 class="collapsible-header" @click="collapsed = !collapsed">
+    <h2 class="panel-header collapsible-header" @click="collapsed = !collapsed">
       <span>Player Debug</span>
       <span class="collapse-indicator" :class="{ collapsed }">&#9660;</span>
     </h2>
@@ -191,33 +191,7 @@ function playerName(pid) {
   border: 1px solid var(--border-panel);
 }
 
-.agent-debug-panel h2 {
-  color: var(--accent);
-  font-size: 0.9rem;
-  margin-bottom: 0.5rem;
-}
-
-.collapsible-header {
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-  cursor: pointer;
-  user-select: none;
-}
-
-.collapsible-header:hover {
-  opacity: 0.85;
-}
-
-.collapse-indicator {
-  font-size: 0.65rem;
-  transition: transform 0.2s ease;
-  color: var(--text-dim);
-}
-
-.collapse-indicator.collapsed {
-  transform: rotate(-90deg);
-}
+/* Panel headers and collapsible headers are in styles/components.css */
 
 /* Agent tabs */
 .agent-tabs {

--- a/frontend/src/components/ChatPanel.vue
+++ b/frontend/src/components/ChatPanel.vue
@@ -37,7 +37,7 @@
 
     <div class="chat-input">
       <input v-model="inputText" placeholder="Type a message..." maxlength="300" @keyup.enter="sendMessage" />
-      <button :disabled="!inputText.trim()" @click="sendMessage">Send</button>
+      <button class="btn-accent" :disabled="!inputText.trim()" @click="sendMessage">Send</button>
     </div>
   </div>
 </template>
@@ -332,25 +332,9 @@ watch(
 }
 
 .chat-input button {
-  background: linear-gradient(135deg, var(--accent), var(--accent-dark));
-  color: var(--accent-text);
-  border: none;
   padding: 0.45rem 0.8rem;
   border-radius: 4px;
-  cursor: pointer;
-  font-weight: 600;
   font-size: 0.85rem;
   font-family: 'Crimson Text', Georgia, serif;
-  transition: all 0.2s;
-}
-
-.chat-input button:hover:not(:disabled) {
-  box-shadow: 0 2px 8px rgba(212, 168, 73, 0.2);
-  transform: translateY(-1px);
-}
-
-.chat-input button:disabled {
-  opacity: 0.3;
-  cursor: not-allowed;
 }
 </style>

--- a/frontend/src/components/DetectiveNotes.vue
+++ b/frontend/src/components/DetectiveNotes.vue
@@ -1,6 +1,6 @@
 <template>
   <div class="detective-notes">
-    <h3>Detective Notes</h3>
+    <h3 class="panel-header">Detective Notes</h3>
 
     <div class="notes-section">
       <h4>Suspects</h4>
@@ -187,14 +187,7 @@ defineExpose({ markCard, getCardsShownBy })
   font-size: 0.8rem;
 }
 
-h3 {
-  font-family: 'Playfair Display', Georgia, serif;
-  color: var(--accent);
-  margin-bottom: 0.5rem;
-  font-size: 0.9rem;
-  font-weight: 700;
-  letter-spacing: 0.03em;
-}
+/* Panel header is in styles/components.css */
 
 h4 {
   color: var(--text-secondary);

--- a/frontend/src/components/GameBoard.vue
+++ b/frontend/src/components/GameBoard.vue
@@ -81,7 +81,7 @@
         </div>
 
         <!-- Chat -->
-        <section class="chat-panel-wrapper sidebar-panel">
+        <section class="sidebar-panel chat-panel-wrapper">
           <h2 class="panel-header">Chat &amp; Game Log</h2>
           <ChatPanel
             :messages="chatMessages"
@@ -1536,10 +1536,6 @@ watch(
 
 /* Chat */
 .chat-panel-wrapper {
-  background: var(--bg-panel);
-  border: 1px solid var(--border-panel);
-  border-radius: 6px;
-  padding: 0.8rem;
   min-height: 200px;
 }
 

--- a/frontend/src/components/GameBoard.vue
+++ b/frontend/src/components/GameBoard.vue
@@ -81,7 +81,8 @@
         </div>
 
         <!-- Chat -->
-        <section class="chat-panel-wrapper">
+        <section class="chat-panel-wrapper sidebar-panel">
+          <h2 class="panel-header">Chat &amp; Game Log</h2>
           <ChatPanel
             :messages="chatMessages"
             :players="gameState?.players"
@@ -94,7 +95,7 @@
       <div class="sidebar-column">
         <!-- Your Cards -->
         <section v-if="!isObserver" class="sidebar-panel cards-panel">
-          <h2 class="collapsible-header" @click="cardsCollapsed = !cardsCollapsed">
+          <h2 class="panel-header collapsible-header" @click="cardsCollapsed = !cardsCollapsed">
             <span>Your Cards</span>
             <span class="collapse-indicator" :class="{ collapsed: cardsCollapsed }">&#9660;</span>
           </h2>
@@ -140,7 +141,7 @@
 
         <!-- Show Card Request (must respond) -->
         <section v-if="showCardRequest" class="sidebar-panel show-card-request-panel">
-          <h2>You Must Show a Card</h2>
+          <h2 class="panel-header">You Must Show a Card</h2>
           <p class="show-card-desc">
             <strong>{{ playerName(showCardRequest.suggestingPlayerId) }}</strong>
             suggested:
@@ -165,7 +166,7 @@
         <!-- Actions -->
         <section v-if="isMyTurn && !showCardRequest && gameState?.status === 'playing' && !isObserver"
           class="sidebar-panel actions-panel">
-          <h2>Actions</h2>
+          <h2 class="panel-header">Actions</h2>
 
           <!-- Secret Passage -->
           <div v-if="canSecretPassage" class="action-group">
@@ -300,7 +301,7 @@
           </section>
 
           <section v-if="observerPlayerState" class="sidebar-panel cards-panel">
-            <h2>{{ observerSelectedPlayerName }}'s Cards</h2>
+            <h2 class="panel-header">{{ observerSelectedPlayerName }}'s Cards</h2>
             <div v-if="!observerCards.length" class="no-cards">No cards</div>
             <div v-else class="card-hand">
               <div v-for="card in observerSuspectCards" :key="card" class="hand-card card-suspect card-with-image"
@@ -1033,37 +1034,7 @@ watch(
   padding: 0.8rem;
 }
 
-.sidebar-panel h2 {
-  font-family: 'Playfair Display', Georgia, serif;
-  color: var(--accent);
-  font-size: 0.9rem;
-  font-weight: 700;
-  margin-bottom: 0.5rem;
-  letter-spacing: 0.03em;
-}
-
-/* Collapsible header */
-.collapsible-header {
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-  cursor: pointer;
-  user-select: none;
-}
-
-.collapsible-header:hover {
-  opacity: 0.85;
-}
-
-.collapse-indicator {
-  font-size: 0.6rem;
-  transition: transform 0.2s ease;
-  color: var(--text-dim);
-}
-
-.collapse-indicator.collapsed {
-  transform: rotate(-90deg);
-}
+/* Panel headers and collapsible headers are in styles/components.css */
 
 /* Cards */
 .card-hand {

--- a/frontend/src/components/Lobby.vue
+++ b/frontend/src/components/Lobby.vue
@@ -94,7 +94,7 @@
                       <option value="llm_agent">LLM Agent</option>
                     </select>
                   </div>
-                  <button class="btn-primary" :disabled="!playerName" @click="joinUrlGame">
+                  <button class="btn-accent btn-primary" :disabled="!playerName" @click="joinUrlGame">
                     Join Game
                   </button>
                 </div>
@@ -114,7 +114,7 @@
                 </select>
               </div>
               <div class="btn-row">
-                <button class="btn-primary" :disabled="!playerName" @click="joinUrlGame">
+                <button class="btn-accent btn-primary" :disabled="!playerName" @click="joinUrlGame">
                   Join Game
                 </button>
                 <button class="btn-secondary" @click="observeUrlGame">
@@ -205,7 +205,7 @@
                         <span class="checkbox-label">Allow rebuys</span>
                       </label>
                     </template>
-                    <button class="btn-primary" :disabled="!playerName" @click="createGame">
+                    <button class="btn-accent btn-primary" :disabled="!playerName" @click="createGame">
                       {{ selectedGame === 'holdem' ? 'Deal Me In' : 'Start Game' }}
                     </button>
                   </div>
@@ -235,7 +235,7 @@
                       </select>
                     </div>
                     <div class="btn-row">
-                      <button class="btn-primary" :disabled="!joinGameId || !playerName" @click="joinGame">
+                      <button class="btn-accent btn-primary" :disabled="!joinGameId || !playerName" @click="joinGame">
                         Join
                       </button>
                       <button class="btn-secondary" :disabled="!joinGameId" @click="observeGame">
@@ -877,51 +877,16 @@ async function observeGame() {
 /* ==============================
    BUTTONS
    ============================== */
+/* extends .btn-accent from components.css */
 .btn-primary {
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  gap: 0.5rem;
   padding: 0.6rem 1.25rem;
-  border: none;
-  border-radius: 6px;
-  background: linear-gradient(135deg, var(--accent), var(--accent-dark));
-  color: var(--accent-text);
   font-family: 'DM Sans', system-ui, sans-serif;
   font-size: 0.88rem;
-  font-weight: 600;
   letter-spacing: 0.02em;
-  cursor: pointer;
-  transition: all 0.25s;
-  position: relative;
-  overflow: hidden;
-}
-
-.btn-primary::before {
-  content: '';
-  position: absolute;
-  inset: 0;
-  background: linear-gradient(135deg, rgba(255, 255, 255, 0.15), transparent);
-  opacity: 0;
-  transition: opacity 0.25s;
-}
-
-.btn-primary:hover:not(:disabled)::before {
-  opacity: 1;
-}
-
-.btn-primary:hover:not(:disabled) {
-  box-shadow: 0 3px 14px var(--accent-glow);
-  transform: translateY(-1px);
-}
-
-.btn-primary:active:not(:disabled) {
-  transform: translateY(0);
 }
 
 .btn-primary:disabled {
   opacity: 0.35;
-  cursor: not-allowed;
 }
 
 .btn-secondary {

--- a/frontend/src/components/WaitingRoom.vue
+++ b/frontend/src/components/WaitingRoom.vue
@@ -74,7 +74,7 @@
       </div>
 
       <!-- Start game -->
-      <button class="btn-start" :disabled="players.length < 2" @click="startGame">
+      <button class="btn-accent btn-start" :disabled="players.length < 2" @click="startGame">
         <span class="btn-start-text">Begin the Investigation</span>
         <span class="btn-start-arrow">&rarr;</span>
       </button>
@@ -642,56 +642,23 @@ async function startGame() {
   font-size: 0.9rem;
 }
 
-/* === Start button === */
+/* === Start button (extends .btn-accent from components.css) === */
 .btn-start {
-  display: inline-flex;
-  align-items: center;
   gap: 0.75rem;
   padding: 0.85rem 2.25rem;
-  border: none;
-  border-radius: 6px;
-  background: linear-gradient(135deg, var(--accent), var(--accent-dark));
-  color: var(--accent-text);
   font-family: 'Playfair Display', Georgia, serif;
   font-size: 1.05rem;
   font-weight: 700;
   letter-spacing: 0.04em;
-  cursor: pointer;
-  transition: all 0.3s;
-  position: relative;
-  overflow: hidden;
   animation: fade-in 0.6s ease-out 0.6s both;
-}
-
-.btn-start::before {
-  content: '';
-  position: absolute;
-  inset: 0;
-  background: linear-gradient(135deg, rgba(255, 255, 255, 0.15), transparent);
-  opacity: 0;
-  transition: opacity 0.3s;
-}
-
-.btn-start:hover:not(:disabled)::before {
-  opacity: 1;
 }
 
 .btn-start:hover:not(:disabled) {
   box-shadow: 0 6px 30px rgba(212, 168, 73, 0.25);
-  transform: translateY(-1px);
 }
 
 .btn-start:hover:not(:disabled) .btn-start-arrow {
   transform: translateX(3px);
-}
-
-.btn-start:active:not(:disabled) {
-  transform: translateY(0);
-}
-
-.btn-start:disabled {
-  opacity: 0.3;
-  cursor: not-allowed;
 }
 
 .btn-start-arrow {

--- a/frontend/src/main.js
+++ b/frontend/src/main.js
@@ -1,4 +1,5 @@
 import { createApp } from 'vue'
 import './styles/themes.css'
+import './styles/components.css'
 import App from './App.vue'
 createApp(App).mount('#app')

--- a/frontend/src/styles/components.css
+++ b/frontend/src/styles/components.css
@@ -3,10 +3,10 @@
    Import globally from main.js so these are NOT scoped
    ================================================================ */
 
-@import url('https://fonts.googleapis.com/css2?family=Playfair+Display:wght@700&family=Crimson+Text:ital,wght@0,400;0,600;1,400&display=swap');
+@import url('https://fonts.googleapis.com/css2?family=Playfair+Display:ital,wght@0,400;0,700;0,900;1,400&family=Crimson+Text:ital,wght@0,400;0,600;1,400&display=swap');
 
-/* ── Panel section headers ── */
-.panel-header {
+/* ── Panel section headers (scoped to headings to avoid colliding with existing .panel-header divs) ── */
+:where(h1, h2, h3, h4, h5, h6).panel-header {
   font-family: 'Playfair Display', Georgia, serif;
   color: var(--accent);
   font-size: 0.9rem;
@@ -69,7 +69,7 @@
 }
 
 .btn-accent:hover:not(:disabled) {
-  box-shadow: 0 3px 14px rgba(212, 168, 73, 0.25);
+  box-shadow: 0 3px 14px var(--accent-glow, rgba(212, 168, 73, 0.25));
   transform: translateY(-1px);
 }
 

--- a/frontend/src/styles/components.css
+++ b/frontend/src/styles/components.css
@@ -1,0 +1,83 @@
+/* ================================================================
+   Shared component styles — reusable across Vue components
+   Import globally from main.js so these are NOT scoped
+   ================================================================ */
+
+@import url('https://fonts.googleapis.com/css2?family=Playfair+Display:wght@700&family=Crimson+Text:ital,wght@0,400;0,600;1,400&display=swap');
+
+/* ── Panel section headers ── */
+.panel-header {
+  font-family: 'Playfair Display', Georgia, serif;
+  color: var(--accent);
+  font-size: 0.9rem;
+  font-weight: 700;
+  margin-bottom: 0.5rem;
+  letter-spacing: 0.03em;
+}
+
+/* ── Collapsible header ── */
+.collapsible-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  cursor: pointer;
+  user-select: none;
+}
+
+.collapsible-header:hover {
+  opacity: 0.85;
+}
+
+.collapse-indicator {
+  font-size: 0.6rem;
+  transition: transform 0.2s ease;
+  color: var(--text-dim);
+}
+
+.collapse-indicator.collapsed {
+  transform: rotate(-90deg);
+}
+
+/* ── Accent button (gradient gold) ── */
+.btn-accent {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 0.5rem;
+  border: none;
+  border-radius: 6px;
+  background: linear-gradient(135deg, var(--accent), var(--accent-dark));
+  color: var(--accent-text);
+  font-weight: 600;
+  cursor: pointer;
+  transition: all 0.25s;
+  position: relative;
+  overflow: hidden;
+}
+
+.btn-accent::before {
+  content: '';
+  position: absolute;
+  inset: 0;
+  background: linear-gradient(135deg, rgba(255, 255, 255, 0.15), transparent);
+  opacity: 0;
+  transition: opacity 0.25s;
+}
+
+.btn-accent:hover:not(:disabled)::before {
+  opacity: 1;
+}
+
+.btn-accent:hover:not(:disabled) {
+  box-shadow: 0 3px 14px rgba(212, 168, 73, 0.25);
+  transform: translateY(-1px);
+}
+
+.btn-accent:active:not(:disabled) {
+  transform: translateY(0);
+}
+
+.btn-accent:disabled {
+  opacity: 0.3;
+  cursor: not-allowed;
+}


### PR DESCRIPTION
## Summary
- Created `frontend/src/styles/components.css` with shared `.panel-header`, `.collapsible-header`, and `.btn-accent` styles
- Removed duplicate CSS from 6 Vue components (GameBoard, AgentDebugPanel, DetectiveNotes, ChatPanel, WaitingRoom, Lobby)
- Added "Chat & Game Log" header to the combined chat panel using the shared panel-header class
- Net reduction of ~60 lines of CSS

## Test plan
- [ ] Verify panel headers (Your Cards, Detective Notes, Chat & Game Log, Actions, Player Debug) render with correct Playfair Display font and accent color across all three themes
- [ ] Verify collapsible panels (Your Cards, Player Debug) still expand/collapse with rotation animation
- [ ] Verify accent buttons (Send chat, Begin Investigation, Create/Join game) retain correct gradient, hover lift, and disabled states
- [ ] Check all three themes (dark, light, vintage)

🤖 Generated with [Claude Code](https://claude.com/claude-code)