### PR TITLE
fix: admin observe game navigates to empty screen

### DIFF
--- a/frontend/src/App.vue
+++ b/frontend/src/App.vue
@@ -441,13 +441,7 @@ function onAdminGoHome() {
 
 function onAdminObserveGame({ gameId: gid, gameType: gType }) {
   isAdminRoute.value = false
-  currentGameType.value = gType
-  gameId.value = gid
-  isObserver.value = true
-  urlGameId.value = null
-  pushGameUrl(gid)
-  connectWS()
-  fetchState(gid)
+  onObserve({ gameId: gid, gameType: gType })
 }
 
 function onGameJoined({ gameId: gid, playerId: pid, state, gameType: gType }) {


### PR DESCRIPTION
## Summary
- **Bug**: Clicking "Observe Game" from the admin page showed an empty game select screen instead of the game
- **Root cause**: `onAdminObserveGame` never set a `playerId`, so `connectWS()` bailed out immediately. It also called a non-existent `fetchState()` function
- **Fix**: Delegate to the existing `onObserve` function which correctly generates an observer ID, fetches game state, and connects the WebSocket

## Test plan
- [ ] Go to admin page, select an active game, click "Observe Game"
- [ ] Verify the game board loads and displays correctly in observer/spectator mode
- [ ] Verify the Lobby "Observe" button still works as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)