### PR TITLE
feat: add chat filter checkbox and enhance agent debug panel

### DIFF
--- a/backend/app/games/clue/agents.py
+++ b/backend/app/games/clue/agents.py
@@ -487,7 +487,7 @@ class BaseAgent(ABC):
     ):
         self.own_cards: set[str] = set(cards)
         self.seen_cards: set[str] = set(cards)  # own hand + directly shown
-        self.inferred_cards: set[str] = set()    # deduced via elimination
+        self.inferred_cards: set[str] = set()  # deduced via elimination
         self.shown_to: dict[str, set[str]] = {}
         self.rooms_suggested_in: set[str] = set()
         self.unrefuted_suggestions: list[dict] = []
@@ -534,12 +534,16 @@ class BaseAgent(ABC):
             "shown_to": {k: sorted(v) for k, v in self.shown_to.items()},
             "rooms_suggested_in": sorted(self.rooms_suggested_in),
             "unrefuted_suggestions": list(self.unrefuted_suggestions),
-            "player_has_cards": {k: sorted(v) for k, v in self.player_has_cards.items()},
+            "player_has_cards": {
+                k: sorted(v) for k, v in self.player_has_cards.items()
+            },
             "player_not_has_cards": {
                 k: sorted(v) for k, v in self.player_not_has_cards.items()
             },
             "suggestion_log": list(self.suggestion_log),
-            "card_inference_log": {k: list(v) for k, v in self.card_inference_log.items()},
+            "card_inference_log": {
+                k: list(v) for k, v in self.card_inference_log.items()
+            },
         }
 
     def load_knowledge_state(self, data: dict):
@@ -568,7 +572,9 @@ class BaseAgent(ABC):
             return
         try:
             key = self._knowledge_redis_key()
-            await self._redis.set(key, json.dumps(self.get_knowledge_state()), ex=EXPIRY)
+            await self._redis.set(
+                key, json.dumps(self.get_knowledge_state()), ex=EXPIRY
+            )
         except Exception:
             logger.debug("Failed to save knowledge state for %s", self.player_id)
 
@@ -598,7 +604,9 @@ class BaseAgent(ABC):
                     seen_cards=len(self.seen_cards),
                     suggestion_log=len(self.suggestion_log),
                     player_has=sum(len(v) for v in self.player_has_cards.values()),
-                    player_not_has=sum(len(v) for v in self.player_not_has_cards.values()),
+                    player_not_has=sum(
+                        len(v) for v in self.player_not_has_cards.values()
+                    ),
                 )
         except Exception:
             logger.debug("Failed to load knowledge state for %s", self.player_id)
@@ -749,9 +757,7 @@ class BaseAgent(ABC):
                 f"{suspect}/{weapon}/{room} — deduced by elimination."
             )
             self.card_inference_log.setdefault(inferred, []).append(reason)
-            self._pending_inferences.append(
-                f"DEDUCED: {reason}"
-            )
+            self._pending_inferences.append(f"DEDUCED: {reason}")
             self.inferred_cards.add(inferred)
             self._run_inference()
         else:
@@ -1480,6 +1486,10 @@ You are playing Clue (Cluedo) as {character}.
 
 {personality}
 
+Game rule reminder:
+- A suggestion (suspect/weapon/room) is for gathering information and does not end your game.
+- An accusation is a final solve attempt. If your accusation is wrong, you are eliminated from the game.
+
 Respond with a valid JSON object for your chosen action. Include a "chat" field \
 with a short in-character comment (one sentence, stay in character). Be coy and \
 lie in the chat; it's for flavor, not factual reporting.
@@ -1626,7 +1636,6 @@ class LLMAgent(BaseAgent):
         self._fallback.suggestion_log = self.suggestion_log
         self._fallback.card_inference_log = self.card_inference_log
 
-
     async def load_memory(self):
         """Load memory from Redis into the in-memory list."""
         if self._redis and self._game_id and self.player_id:
@@ -1634,8 +1643,6 @@ class LLMAgent(BaseAgent):
 
             game = ClueGame(self._game_id, self._redis)
             self.memory = await game.get_memory(self.player_id)
-
-
 
     async def _save_memory_entry(self, entry: str):
         """Append a memory entry both in-memory and to Redis."""

--- a/frontend/src/components/AgentDebugPanel.vue
+++ b/frontend/src/components/AgentDebugPanel.vue
@@ -23,6 +23,36 @@
             }}</span>
         </div>
 
+        <!-- Player Info -->
+        <div class="debug-section player-info-section">
+          <div class="info-row">
+            <span class="info-label">Type:</span>
+            <span class="info-value agent-type-badge" :class="'type-' + (currentDebug.agent_type || 'human')">{{
+              currentDebug.agent_type || 'human' }}</span>
+          </div>
+          <div class="info-row">
+            <span class="info-label">Active:</span>
+            <span class="info-value" :class="selectedPlayer?.active !== false ? 'active-yes' : 'active-no'">{{
+              selectedPlayer?.active !== false ? 'Yes' : 'Eliminated' }}</span>
+          </div>
+          <div class="info-row">
+            <span class="info-label">Turn:</span>
+            <span v-if="isTheirTurn" class="info-value turn-active">
+              Their turn
+              <span v-if="turnState">({{ turnState.diceRolled ? 'rolled' : 'not rolled' }}<span v-if="turnState.lastRoll">, {{ turnState.lastRoll.reduce((a, b) => a + b, 0) }} spaces</span>{{ turnState.moved ? ', moved' : '' }})</span>
+            </span>
+            <span v-else class="info-value turn-waiting">Waiting</span>
+          </div>
+          <div v-if="wasMovedBySuggestion" class="info-row">
+            <span class="info-label"></span>
+            <span class="info-value moved-by-suggestion">Moved by suggestion</span>
+          </div>
+          <div v-if="props.gameState" class="info-row">
+            <span class="info-label">Turn #:</span>
+            <span class="info-value">{{ props.gameState.turn_number }}</span>
+          </div>
+        </div>
+
         <!-- Position & Room -->
         <div class="debug-section location-section">
           <div class="location-row">
@@ -78,6 +108,10 @@
             <div class="seen-cards-line">
               <span class="seen-label">Seen:</span>
               <span class="seen-list">{{ currentDebug.seen_cards?.join(', ') || 'none' }}</span>
+            </div>
+            <div v-if="currentDebug.inferred_cards?.length" class="seen-cards-line">
+              <span class="seen-label">Inferred:</span>
+              <span class="inferred-list">{{ currentDebug.inferred_cards.join(', ') }}</span>
             </div>
           </div>
         </div>
@@ -136,7 +170,8 @@ import { ref, computed, watch } from 'vue'
 
 const props = defineProps({
   agentDebugData: { type: Object, default: () => ({}) },
-  players: { type: Array, default: () => [] }
+  players: { type: Array, default: () => [] },
+  gameState: { type: Object, default: null }
 })
 
 const collapsed = ref(false)
@@ -168,6 +203,28 @@ watch(
 const currentDebug = computed(() => {
   if (!selectedAgent.value) return null
   return props.agentDebugData[selectedAgent.value] || null
+})
+
+const selectedPlayer = computed(() => {
+  if (!selectedAgent.value || !props.players?.length) return null
+  return props.players.find((p) => p.id === selectedAgent.value) || null
+})
+
+const isTheirTurn = computed(() => {
+  return props.gameState?.whose_turn === selectedAgent.value
+})
+
+const wasMovedBySuggestion = computed(() => {
+  return props.gameState?.was_moved_by_suggestion?.[selectedAgent.value] ?? false
+})
+
+const turnState = computed(() => {
+  if (!isTheirTurn.value || !props.gameState) return null
+  return {
+    diceRolled: props.gameState.dice_rolled,
+    moved: props.gameState.moved,
+    lastRoll: props.gameState.last_roll
+  }
 })
 
 function agentLabel(pid) {
@@ -440,6 +497,89 @@ function playerName(pid) {
 
 .memory-text {
   color: var(--text-secondary);
+  word-break: break-word;
+}
+
+/* Player info */
+.player-info-section {
+  display: flex;
+  flex-direction: column;
+  gap: 0.15rem;
+}
+
+.info-row {
+  display: flex;
+  align-items: center;
+  gap: 0.3rem;
+  font-size: 0.7rem;
+}
+
+.info-label {
+  color: var(--text-secondary);
+  font-weight: bold;
+  text-transform: uppercase;
+  font-size: 0.65rem;
+  min-width: 60px;
+}
+
+.info-value {
+  color: var(--text-secondary);
+}
+
+.agent-type-badge {
+  padding: 0.05rem 0.3rem;
+  border-radius: 3px;
+  font-size: 0.65rem;
+  font-weight: bold;
+  text-transform: uppercase;
+}
+
+.type-random {
+  background: var(--badge-clue-bg);
+  color: var(--badge-clue-text);
+}
+
+.type-llm {
+  background: var(--accent-bg);
+  color: var(--accent);
+}
+
+.type-human {
+  background: var(--bg-input);
+  color: var(--text-muted);
+}
+
+.type-wanderer {
+  background: var(--tag-wanderer-bg);
+  color: var(--tag-wanderer-text);
+}
+
+.active-yes {
+  color: var(--success);
+}
+
+.active-no {
+  color: var(--error, #e74c3c);
+  font-weight: bold;
+}
+
+.turn-active {
+  color: #f39c12;
+  font-weight: bold;
+}
+
+.turn-waiting {
+  color: var(--text-dim);
+}
+
+.moved-by-suggestion {
+  color: #f39c12;
+  font-style: italic;
+  font-size: 0.65rem;
+}
+
+.inferred-list {
+  color: var(--accent);
   word-break: break-word;
 }
 

--- a/frontend/src/components/ChatPanel.vue
+++ b/frontend/src/components/ChatPanel.vue
@@ -17,6 +17,10 @@
         <input type="checkbox" v-model="showMoves" />
         Moves &amp; Rolls
       </label>
+      <label class="filter-label">
+        <input type="checkbox" v-model="showChat" />
+        Chat
+      </label>
     </div>
 
     <ul class="chat-messages" ref="chatContainer">
@@ -60,6 +64,7 @@ const showSuggestions = ref(true)
 const showCardShows = ref(true)
 const showAccusations = ref(true)
 const showMoves = ref(true)
+const showChat = ref(true)
 
 const playerById = computed(() => {
   const map = {}
@@ -101,7 +106,7 @@ function logCategory(msg) {
 // Combined messages: all player chat + filtered system log, in original order
 const combinedMessages = computed(() => {
   return props.messages.filter((msg) => {
-    if (isPlayerChat(msg)) return true
+    if (isPlayerChat(msg)) return showChat.value
     const cat = logCategory(msg)
     if (cat === 'suggestion' && !showSuggestions.value) return false
     if (cat === 'cardshow' && !showCardShows.value) return false

--- a/frontend/src/components/GameBoard.vue
+++ b/frontend/src/components/GameBoard.vue
@@ -363,7 +363,7 @@
           <section v-if="observerSelectedDebug" class="sidebar-panel">
             <AgentDebugPanel :agent-debug-data="{
               [observerPlayerState.playerId]: observerSelectedDebug
-            }" :players="gameState?.players" />
+            }" :players="gameState?.players" :game-state="gameState" />
           </section>
         </template>
       </div>

--- a/frontend/src/components/GameDebug.vue
+++ b/frontend/src/components/GameDebug.vue
@@ -184,10 +184,14 @@
           <div class="agent-section">
             <h3>Status & Location</h3>
             <div class="kv-list">
-              <div class="kv-row"><span class="kv-key">Type</span><span class="kv-val">{{ selectedAgent.agent_type }}</span></div>
+              <div class="kv-row"><span class="kv-key">Type</span><span class="kv-val"><span class="type-badge" :class="'type-' + agentPlayerType">{{ selectedAgent.agent_type }}</span></span></div>
               <div class="kv-row"><span class="kv-key">Status</span><span class="kv-val">{{ selectedAgent.status }}</span></div>
+              <div class="kv-row"><span class="kv-key">Active</span><span class="kv-val" :class="agentPlayer?.active !== false ? 'text-success' : 'text-error'">{{ agentPlayer?.active !== false ? 'Yes' : 'Eliminated' }}</span></div>
+              <div class="kv-row"><span class="kv-key">Turn</span><span class="kv-val" :class="isAgentTurn ? 'text-turn-active' : ''">{{ isAgentTurn ? 'Their turn' : 'Waiting' }}<span v-if="isAgentTurn && debugData.state"> ({{ debugData.state.dice_rolled ? 'rolled' : 'not rolled' }}<span v-if="debugData.state.last_roll">, {{ debugData.state.last_roll.reduce((a, b) => a + b, 0) }} spaces</span>{{ debugData.state.moved ? ', moved' : '' }})</span></span></div>
+              <div class="kv-row" v-if="debugData.state?.was_moved_by_suggestion?.[selectedAgentId]"><span class="kv-key"></span><span class="kv-val text-warning">Moved by suggestion</span></div>
               <div class="kv-row"><span class="kv-key">Room</span><span class="kv-val">{{ selectedAgent.room || 'Hallway' }}</span></div>
               <div class="kv-row"><span class="kv-key">Position</span><span class="kv-val">{{ selectedAgent.position ? `[${selectedAgent.position[0]}, ${selectedAgent.position[1]}]` : '—' }}</span></div>
+              <div class="kv-row" v-if="selectedAgent.reachable_rooms?.length"><span class="kv-key">Reachable</span><span class="kv-val"><span v-for="r in selectedAgent.reachable_rooms" :key="r" class="chip room-chip">{{ r }}</span></span></div>
               <div class="kv-row" v-if="selectedAgent.action_description"><span class="kv-key">Last Action</span><span class="kv-val">{{ selectedAgent.action_description }}</span></div>
             </div>
           </div>
@@ -220,6 +224,9 @@
             </div>
             <div v-if="selectedAgent.seen_cards?.length" class="seen-line">
               <strong>Seen:</strong> {{ selectedAgent.seen_cards.join(', ') }}
+            </div>
+            <div v-if="selectedAgent.inferred_cards?.length" class="seen-line inferred-line">
+              <strong>Inferred:</strong> {{ selectedAgent.inferred_cards.join(', ') }}
             </div>
           </div>
 
@@ -384,6 +391,20 @@ const agentList = computed(() => {
 const selectedAgent = computed(() => {
   if (!selectedAgentId.value || !debugData.value) return null
   return debugData.value.agent_debug.find(a => a.player_id === selectedAgentId.value) || null
+})
+
+const agentPlayer = computed(() => {
+  if (!selectedAgentId.value) return null
+  return playerMap.value[selectedAgentId.value] || null
+})
+
+const agentPlayerType = computed(() => {
+  const t = agentPlayer.value?.type
+  return { agent: 'agent', llm_agent: 'llm_agent', wanderer: 'wanderer' }[t] || 'human'
+})
+
+const isAgentTurn = computed(() => {
+  return debugData.value?.state?.whose_turn === selectedAgentId.value
 })
 
 const agentMemory = computed(() => {
@@ -1242,7 +1263,11 @@ onUnmounted(() => {
 /* Utility */
 .text-success { color: #2ecc71; }
 .text-error { color: #ff6666; }
+.text-warning { color: #f39c12; font-style: italic; }
+.text-turn-active { color: #f39c12; font-weight: bold; }
 .text-dim { color: var(--text-dim); }
+
+.inferred-line { color: var(--accent, #60a5fa); }
 
 .empty-state {
   text-align: center;


### PR DESCRIPTION
## Summary
- Add **Chat** filter toggle to ChatPanel so players can show/hide player chat messages alongside existing log filters
- Add player info section to AgentDebugPanel showing agent type, active status, turn state, and moved-by-suggestion indicator
- Display inferred cards in both AgentDebugPanel and GameDebug views
- Add game rule reminder to LLM agent prompt clarifying suggestion vs accusation
- Minor formatting cleanup in agents.py

## Test plan
- [ ] Verify Chat checkbox appears in chat panel filters and toggles player messages on/off
- [ ] Verify agent debug panel shows player type, active status, and turn info
- [ ] Verify inferred cards display in debug panels
- [ ] Run backend tests (`cd backend && pytest`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)