### PR TITLE
Add /api prefix to all backend routes and update frontend/scripts

### DIFF
--- a/backend/agent_runner.py
+++ b/backend/agent_runner.py
@@ -9,7 +9,7 @@ Discovery:
 
 Communication:
   - Connects to the backend via WebSocket for real-time game events.
-  - Submits actions via the backend HTTP API (POST /games/{game_id}/action).
+  - Submits actions via the backend HTTP API (POST /api/games/{game_id}/action).
   - Fetches player state via HTTP GET when making decisions.
 """
 
@@ -361,7 +361,7 @@ class AgentRunner:
         agent: BaseAgent,
     ):
         """Drive a single agent via a WebSocket connection to the backend."""
-        ws_url = f"{_WS_URL}/ws/{game_id}/{player_id}"
+        ws_url = f"{_WS_URL}/api/ws/{game_id}/{player_id}"
         logger.info("Connecting agent %s to WebSocket %s", player_id, ws_url)
 
         max_reconnects = 5
@@ -451,7 +451,7 @@ class AgentRunner:
             await asyncio.sleep(1.35)
 
         # Fetch fresh player state from the backend
-        resp = await self.http.get(f"/games/{game_id}/player/{player_id}")
+        resp = await self.http.get(f"/api/games/{game_id}/player/{player_id}")
         if resp.status_code != 200:
             logger.warning(
                 "Failed to fetch player state for %s in game %s: %s",
@@ -601,7 +601,7 @@ class AgentRunner:
                 decided_action=action.model_dump() if action else None,
             )
             await self.http.post(
-                f"/games/{game_id}/agent_debug",
+                f"/api/games/{game_id}/agent_debug",
                 json=debug_info,
             )
         except Exception:
@@ -612,7 +612,7 @@ class AgentRunner:
     async def _send_action(self, game_id: str, player_id: str, action: dict) -> dict:
         """Send an action to the backend via the HTTP API."""
         resp = await self.http.post(
-            f"/games/{game_id}/action",
+            f"/api/games/{game_id}/action",
             json={"player_id": player_id, "action": action},
         )
         if resp.status_code == 400:
@@ -633,7 +633,7 @@ class AgentRunner:
         logger.info("Sending chat from %s in game %s: %s", player_id, game_id, text)
         try:
             await self.http.post(
-                f"/games/{game_id}/chat",
+                f"/api/games/{game_id}/chat",
                 json={"player_id": player_id, "text": text},
             )
         except Exception:

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -1214,7 +1214,7 @@ async def _run_agent_loop(game_id: str):
 # ---------------------------------------------------------------------------
 
 
-@app.post("/games", status_code=201, response_model=CreateGameResponse)
+@app.post("/api/games", status_code=201, response_model=CreateGameResponse)
 async def create_game():
     game_id = _new_id(6)
     game = ClueGame(game_id, redis_client)
@@ -1222,7 +1222,7 @@ async def create_game():
     return CreateGameResponse(game_id=game_id, status=state.status)
 
 
-@app.get("/healthz")
+@app.get("/api/healthz")
 async def healthz():
     return OkResponse()
 
@@ -1232,7 +1232,7 @@ async def healthz():
 # ---------------------------------------------------------------------------
 
 
-@app.get("/admin/games")
+@app.get("/api/admin/games")
 async def admin_list_games():
     """Return summary info for every active game (Clue + Hold'em)."""
     games: list[dict] = []
@@ -1311,7 +1311,7 @@ async def admin_list_games():
     return {"games": games}
 
 
-@app.get("/admin/games/{game_id}")
+@app.get("/api/admin/games/{game_id}")
 async def admin_get_game(game_id: str):
     """Return full raw state for a specific game (admin view)."""
     # Try Clue first
@@ -1334,7 +1334,7 @@ async def admin_get_game(game_id: str):
     raise HTTPException(status_code=404, detail="Game not found")
 
 
-@app.get("/board")
+@app.get("/api/board")
 async def get_board():
     """Return static board layout data (doors, rooms, starts, passages)."""
     return {
@@ -1356,7 +1356,7 @@ async def get_board():
     }
 
 
-@app.get("/games/{game_id}")
+@app.get("/api/games/{game_id}")
 async def get_game(game_id: str):
     game = ClueGame(game_id, redis_client)
     state = await game.get_state()
@@ -1365,7 +1365,7 @@ async def get_game(game_id: str):
     return state.model_dump()
 
 
-@app.get("/games/{game_id}/debug")
+@app.get("/api/games/{game_id}/debug")
 async def get_game_debug(
     game_id: str,
     trace_limit: int = 500,
@@ -1459,7 +1459,7 @@ async def get_game_debug(
     }
 
 
-@app.get("/games/{game_id}/player/{player_id}")
+@app.get("/api/games/{game_id}/player/{player_id}")
 async def get_player_state(game_id: str, player_id: str):
     game = ClueGame(game_id, redis_client)
     player_state = await game.get_player_state(player_id)
@@ -1468,7 +1468,7 @@ async def get_player_state(game_id: str, player_id: str):
     return player_state.model_dump()
 
 
-@app.get("/games/{game_id}/agent_debug")
+@app.get("/api/games/{game_id}/agent_debug")
 async def get_agent_debug(game_id: str):
     """Return current debug info for all players (agents and humans) in a game."""
     game = ClueGame(game_id, redis_client)
@@ -1539,7 +1539,7 @@ async def get_agent_debug(game_id: str):
     return {"agents": result}
 
 
-@app.post("/games/{game_id}/agent_debug")
+@app.post("/api/games/{game_id}/agent_debug")
 async def post_agent_debug(game_id: str, request: Request):
     """Receive agent debug info from external agent runner, store and broadcast."""
     data = await request.json()
@@ -1562,7 +1562,7 @@ async def post_agent_debug(game_id: str, request: Request):
     await manager.broadcast(game_id, AgentDebugMessage(**data))
 
 
-@app.get("/games/{game_id}/agent_trace")
+@app.get("/api/games/{game_id}/agent_trace")
 async def get_agent_trace(game_id: str, limit: int = 200, offset: int = 0):
     """Return agent trace entries from Redis for debugging."""
     key = f"game:{game_id}:agent_trace"
@@ -1576,7 +1576,7 @@ async def get_agent_trace(game_id: str, limit: int = 200, offset: int = 0):
     }
 
 
-@app.put("/games/{game_id}/agent_trace")
+@app.put("/api/games/{game_id}/agent_trace")
 async def toggle_agent_trace(game_id: str, request: Request):
     """Enable or disable agent tracing for a specific game."""
     data = await request.json()
@@ -1590,7 +1590,7 @@ async def toggle_agent_trace(game_id: str, request: Request):
     return {"agent_trace_enabled": enabled}
 
 
-@app.post("/games/{game_id}/join")
+@app.post("/api/games/{game_id}/join")
 async def join_game(game_id: str, req: JoinRequest):
     game = ClueGame(game_id, redis_client)
     player_id = _new_player_id()
@@ -1608,7 +1608,7 @@ async def join_game(game_id: str, req: JoinRequest):
     return JoinGameResponse(player_id=player_id, player=player)
 
 
-@app.post("/games/{game_id}/add_agent")
+@app.post("/api/games/{game_id}/add_agent")
 async def add_agent(game_id: str, req: AddAgentRequest | None = None):
     """Add an AI agent to a game in the waiting room."""
     agent_type = req.agent_type if req else "agent"
@@ -1637,7 +1637,7 @@ async def add_agent(game_id: str, req: AddAgentRequest | None = None):
     return JoinGameResponse(player_id=player_id, player=player)
 
 
-@app.post("/games/{game_id}/start")
+@app.post("/api/games/{game_id}/start")
 async def start_game(game_id: str):
     game = ClueGame(game_id, redis_client)
     try:
@@ -1764,7 +1764,7 @@ async def start_game(game_id: str):
     return state.model_dump()
 
 
-@app.post("/games/{game_id}/action")
+@app.post("/api/games/{game_id}/action")
 async def submit_action(game_id: str, req: ActionRequest):
     try:
         result = await _execute_action(game_id, req.player_id, req.action)
@@ -1784,7 +1784,7 @@ async def submit_action(game_id: str, req: ActionRequest):
 # ---------------------------------------------------------------------------
 
 
-@app.put("/games/{game_id}/notes")
+@app.put("/api/games/{game_id}/notes")
 async def save_notes(game_id: str, req: SaveNotesRequest):
     game = ClueGame(game_id, redis_client)
     state = await game.get_state()
@@ -1799,7 +1799,7 @@ async def save_notes(game_id: str, req: SaveNotesRequest):
 # ---------------------------------------------------------------------------
 
 
-@app.websocket("/ws/{game_id}/{player_id}")
+@app.websocket("/api/ws/{game_id}/{player_id}")
 async def websocket_endpoint(websocket: WebSocket, game_id: str, player_id: str):
     await manager.connect(game_id, player_id, websocket)
     game = ClueGame(game_id, redis_client)
@@ -1866,7 +1866,7 @@ async def websocket_endpoint(websocket: WebSocket, game_id: str, player_id: str)
 # ---------------------------------------------------------------------------
 
 
-@app.get("/games/{game_id}/chat")
+@app.get("/api/games/{game_id}/chat")
 async def get_chat(game_id: str):
     game = ClueGame(game_id, redis_client)
     state = await game.get_state()
@@ -1876,7 +1876,7 @@ async def get_chat(game_id: str):
     return ChatMessagesResponse(messages=messages)
 
 
-@app.post("/games/{game_id}/chat")
+@app.post("/api/games/{game_id}/chat")
 async def send_chat(game_id: str, req: ChatRequest):
     game = ClueGame(game_id, redis_client)
     state = await game.get_state()
@@ -1912,7 +1912,7 @@ async def _holdem_broadcast_chat(game_id: str, text: str, player_id: str | None 
     )
 
 
-@app.post("/holdem/games", status_code=201, response_model=HoldemCreateGameResponse)
+@app.post("/api/holdem/games", status_code=201, response_model=HoldemCreateGameResponse)
 async def holdem_create_game(req: HoldemCreateGameRequest | None = None):
     game_id = _new_id(6)
     game = HoldemGame(game_id, redis_client)
@@ -1927,7 +1927,7 @@ async def holdem_create_game(req: HoldemCreateGameRequest | None = None):
     )
 
 
-@app.get("/holdem/games/{game_id}")
+@app.get("/api/holdem/games/{game_id}")
 async def holdem_get_game(game_id: str):
     game = HoldemGame(game_id, redis_client)
     state = await game.get_state()
@@ -1936,7 +1936,7 @@ async def holdem_get_game(game_id: str):
     return state.model_dump()
 
 
-@app.get("/holdem/games/{game_id}/player/{player_id}")
+@app.get("/api/holdem/games/{game_id}/player/{player_id}")
 async def holdem_get_player_state(game_id: str, player_id: str):
     game = HoldemGame(game_id, redis_client)
     ps = await game.get_player_state(player_id)
@@ -1945,7 +1945,7 @@ async def holdem_get_player_state(game_id: str, player_id: str):
     return ps.model_dump()
 
 
-@app.post("/holdem/games/{game_id}/join")
+@app.post("/api/holdem/games/{game_id}/join")
 async def holdem_join_game(game_id: str, req: HoldemJoinRequest):
     game = HoldemGame(game_id, redis_client)
     player_id = _new_player_id()
@@ -1963,7 +1963,7 @@ async def holdem_join_game(game_id: str, req: HoldemJoinRequest):
     return HoldemJoinGameResponse(player_id=player_id, player=player)
 
 
-@app.post("/holdem/games/{game_id}/start")
+@app.post("/api/holdem/games/{game_id}/start")
 async def holdem_start_game(game_id: str):
     game = HoldemGame(game_id, redis_client)
     try:
@@ -2136,7 +2136,7 @@ async def _holdem_execute_action(game_id: str, player_id: str, action):
     return result
 
 
-@app.post("/holdem/games/{game_id}/action")
+@app.post("/api/holdem/games/{game_id}/action")
 async def holdem_submit_action(game_id: str, req: HoldemActionRequest):
     try:
         result = await _holdem_execute_action(game_id, req.player_id, req.action)
@@ -2150,7 +2150,7 @@ async def holdem_submit_action(game_id: str, req: HoldemActionRequest):
     return response
 
 
-@app.websocket("/ws/holdem/{game_id}/{player_id}")
+@app.websocket("/api/ws/holdem/{game_id}/{player_id}")
 async def holdem_websocket_endpoint(websocket: WebSocket, game_id: str, player_id: str):
     await manager.connect(game_id, player_id, websocket)
     game = HoldemGame(game_id, redis_client)
@@ -2193,7 +2193,7 @@ async def holdem_websocket_endpoint(websocket: WebSocket, game_id: str, player_i
         manager.disconnect(game_id, player_id, websocket)
 
 
-@app.get("/holdem/games/{game_id}/chat")
+@app.get("/api/holdem/games/{game_id}/chat")
 async def holdem_get_chat(game_id: str):
     game = HoldemGame(game_id, redis_client)
     state = await game.get_state()
@@ -2203,7 +2203,7 @@ async def holdem_get_chat(game_id: str):
     return HoldemChatMessagesResponse(messages=messages)
 
 
-@app.post("/holdem/games/{game_id}/chat")
+@app.post("/api/holdem/games/{game_id}/chat")
 async def holdem_send_chat(game_id: str, req: HoldemChatRequest):
     game = HoldemGame(game_id, redis_client)
     state = await game.get_state()
@@ -2297,7 +2297,7 @@ async def _run_holdem_agent_loop(game_id: str):
         logger.info("Holdem agent loop ended for game %s", game_id)
 
 
-@app.post("/holdem/games/{game_id}/add_agent")
+@app.post("/api/holdem/games/{game_id}/add_agent")
 async def holdem_add_agent(game_id: str, req: HoldemAddAgentRequest | None = None):
     """Add an AI agent to a Hold'em game in the waiting room."""
     game = HoldemGame(game_id, redis_client)

--- a/backend/tests/test_ws_e2e.py
+++ b/backend/tests/test_ws_e2e.py
@@ -92,7 +92,7 @@ async def http(redis):
 
 
 async def _create_game(http: AsyncClient) -> str:
-    resp = await http.post("/games")
+    resp = await http.post("/api/games")
     assert resp.status_code == 201
     return resp.json()["game_id"]
 
@@ -101,7 +101,7 @@ async def _join_game(
     http: AsyncClient, game_id: str, name: str, player_type: str = "human"
 ) -> str:
     resp = await http.post(
-        f"/games/{game_id}/join",
+        f"/api/games/{game_id}/join",
         json={"player_name": name, "player_type": player_type},
     )
     assert resp.status_code == 200
@@ -123,7 +123,7 @@ async def _assign_characters(redis, game_id: str, assignments: dict[str, str]):
 
 
 async def _start_game(http: AsyncClient, game_id: str) -> dict:
-    resp = await http.post(f"/games/{game_id}/start")
+    resp = await http.post(f"/api/games/{game_id}/start")
     assert resp.status_code == 200
     return resp.json()
 
@@ -134,7 +134,7 @@ async def _submit_action(
     # Convert Pydantic models to dicts for JSON serialization
     action_data = action.model_dump() if hasattr(action, "model_dump") else action
     resp = await http.post(
-        f"/games/{game_id}/action",
+        f"/api/games/{game_id}/action",
         json={"player_id": player_id, "action": action_data},
     )
     assert (
@@ -144,7 +144,7 @@ async def _submit_action(
 
 
 async def _get_state(http: AsyncClient, game_id: str) -> dict:
-    resp = await http.get(f"/games/{game_id}")
+    resp = await http.get(f"/api/games/{game_id}")
     assert resp.status_code == 200
     return resp.json()
 
@@ -899,7 +899,7 @@ class TestChatIntegration:
         ws2.drain()
 
         resp = await http.post(
-            f"/games/{game_id}/chat",
+            f"/api/games/{game_id}/chat",
             json={"player_id": pid1, "text": "Good luck!"},
         )
         assert resp.status_code == 200

--- a/frontend/nginx.conf
+++ b/frontend/nginx.conf
@@ -4,38 +4,14 @@ server {
     root /usr/share/nginx/html;
     index index.html;
 
-    # Proxy REST API to backend
-    location /games {
-        proxy_pass http://backend:8000;
-        proxy_set_header Host $host;
-        proxy_set_header X-Real-IP $remote_addr;
-    }
-
-    location /board {
-        proxy_pass http://backend:8000;
-        proxy_set_header Host $host;
-        proxy_set_header X-Real-IP $remote_addr;
-    }
-
-    location /holdem/games {
-        proxy_pass http://backend:8000;
-        proxy_set_header Host $host;
-        proxy_set_header X-Real-IP $remote_addr;
-    }
-
-    location /admin/games {
-        proxy_pass http://backend:8000;
-        proxy_set_header Host $host;
-        proxy_set_header X-Real-IP $remote_addr;
-    }
-
-    # Proxy WebSocket to backend
-    location /ws {
+    # Proxy API and WebSocket to backend
+    location /api {
         proxy_pass http://backend:8000;
         proxy_http_version 1.1;
         proxy_set_header Upgrade $http_upgrade;
         proxy_set_header Connection "upgrade";
         proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
     }
 
     # SPA fallback

--- a/frontend/src/App.vue
+++ b/frontend/src/App.vue
@@ -160,7 +160,7 @@ onMounted(async () => {
     urlGameId.value = parsed.gameId
   }
   try {
-    const res = await fetch('/board')
+    const res = await fetch('/api/board')
     if (res.ok) boardData.value = await res.json()
   } catch (_) {
     /* fall back to hardcoded board data */
@@ -178,8 +178,8 @@ function connectWS() {
   const proto = location.protocol === 'https:' ? 'wss' : 'ws'
   const wsPath =
     currentGameType.value === 'holdem'
-      ? `/ws/holdem/${gameId.value}/${playerId.value}`
-      : `/ws/${gameId.value}/${playerId.value}`
+      ? `/api/ws/holdem/${gameId.value}/${playerId.value}`
+      : `/api/ws/${gameId.value}/${playerId.value}`
   ws = new WebSocket(`${proto}://${location.host}${wsPath}`)
 
   ws.onopen = () => {
@@ -537,7 +537,7 @@ function onObserve({ gameId: gid, gameType: gType }) {
   urlGameId.value = null
 
   // Fetch current state
-  const endpoint = currentGameType.value === 'holdem' ? `/holdem/games/${gid}` : `/games/${gid}`
+  const endpoint = currentGameType.value === 'holdem' ? `/api/holdem/games/${gid}` : `/api/games/${gid}`
   fetch(endpoint)
     .then((r) => r.json())
     .then((state) => {
@@ -565,7 +565,7 @@ function onRejoin({ gameId: gid, playerId: pid, gameType: gType }) {
   urlGameId.value = null
 
   // Fetch current state
-  const endpoint = currentGameType.value === 'holdem' ? `/holdem/games/${gid}` : `/games/${gid}`
+  const endpoint = currentGameType.value === 'holdem' ? `/api/holdem/games/${gid}` : `/api/games/${gid}`
   fetch(endpoint)
     .then((r) => r.json())
     .then((state) => {
@@ -583,7 +583,7 @@ function onRejoin({ gameId: gid, playerId: pid, gameType: gType }) {
 }
 
 function loadChat(gid) {
-  fetch(`/games/${gid}/chat`)
+  fetch(`/api/games/${gid}/chat`)
     .then((r) => r.json())
     .then((data) => {
       chatMessages.value = data.messages ?? []
@@ -592,7 +592,7 @@ function loadChat(gid) {
 }
 
 function loadAgentDebug(gid) {
-  fetch(`/games/${gid}/agent_debug`)
+  fetch(`/api/games/${gid}/agent_debug`)
     .then((r) => r.json())
     .then((data) => {
       if (data.agents) {
@@ -608,7 +608,7 @@ function loadAgentDebug(gid) {
 
 function onObserverSelectPlayer(pid) {
   if (!isObserver.value || !gameId.value) return
-  fetch(`/games/${gameId.value}/player/${pid}`)
+  fetch(`/api/games/${gameId.value}/player/${pid}`)
     .then((r) => (r.ok ? r.json() : null))
     .then((data) => {
       if (data) {
@@ -628,7 +628,7 @@ function onGameStarted(state) {
 }
 
 async function sendAction(action) {
-  const res = await fetch(`/games/${gameId.value}/action`, {
+  const res = await fetch(`/api/games/${gameId.value}/action`, {
     method: 'POST',
     headers: { 'Content-Type': 'application/json' },
     body: JSON.stringify({ player_id: playerId.value, action })
@@ -638,7 +638,7 @@ async function sendAction(action) {
     if (result.available_actions) availableActions.value = result.available_actions
     // Refresh full state to stay in sync
     try {
-      const stateRes = await fetch(`/games/${gameId.value}`)
+      const stateRes = await fetch(`/api/games/${gameId.value}`)
       if (stateRes.ok) {
         const freshState = await stateRes.json()
         gameState.value = freshState
@@ -650,7 +650,7 @@ async function sendAction(action) {
 }
 
 async function sendChat(text) {
-  await fetch(`/games/${gameId.value}/chat`, {
+  await fetch(`/api/games/${gameId.value}/chat`, {
     method: 'POST',
     headers: { 'Content-Type': 'application/json' },
     body: JSON.stringify({ player_id: playerId.value, text })
@@ -733,7 +733,7 @@ function handleHoldemMessage(msg) {
 async function refreshHoldemState() {
   if (!gameId.value || !playerId.value) return
   try {
-    const res = await fetch(`/holdem/games/${gameId.value}/player/${playerId.value}`)
+    const res = await fetch(`/api/holdem/games/${gameId.value}/player/${playerId.value}`)
     if (res.ok) {
       const state = await res.json()
       gameState.value = state
@@ -746,7 +746,7 @@ async function refreshHoldemState() {
 }
 
 async function sendHoldemAction(action) {
-  const res = await fetch(`/holdem/games/${gameId.value}/action`, {
+  const res = await fetch(`/api/holdem/games/${gameId.value}/action`, {
     method: 'POST',
     headers: { 'Content-Type': 'application/json' },
     body: JSON.stringify({ player_id: playerId.value, action })
@@ -759,7 +759,7 @@ async function sendHoldemAction(action) {
 }
 
 async function sendHoldemChat(text) {
-  await fetch(`/holdem/games/${gameId.value}/chat`, {
+  await fetch(`/api/holdem/games/${gameId.value}/chat`, {
     method: 'POST',
     headers: { 'Content-Type': 'application/json' },
     body: JSON.stringify({ player_id: playerId.value, text })
@@ -767,7 +767,7 @@ async function sendHoldemChat(text) {
 }
 
 function loadHoldemChat(gid) {
-  fetch(`/holdem/games/${gid}/chat`)
+  fetch(`/api/holdem/games/${gid}/chat`)
     .then((r) => r.json())
     .then((data) => {
       chatMessages.value = data.messages ?? []

--- a/frontend/src/components/AdminGames.vue
+++ b/frontend/src/components/AdminGames.vue
@@ -147,7 +147,7 @@ async function fetchGames() {
   loading.value = true
   error.value = null
   try {
-    const res = await fetch('/admin/games')
+    const res = await fetch('/api/admin/games')
     if (!res.ok) throw new Error(`HTTP ${res.status}`)
     const data = await res.json()
     games.value = data.games
@@ -163,7 +163,7 @@ async function openGame(game) {
   detailLoading.value = true
   gameDetail.value = null
   try {
-    const res = await fetch(`/admin/games/${game.game_id}`)
+    const res = await fetch(`/api/admin/games/${game.game_id}`)
     if (!res.ok) throw new Error(`HTTP ${res.status}`)
     gameDetail.value = await res.json()
   } catch (e) {

--- a/frontend/src/components/GameBoard.vue
+++ b/frontend/src/components/GameBoard.vue
@@ -749,7 +749,7 @@ let saveNotesTimer = null
 function onNotesChanged(notesData) {
   if (saveNotesTimer) clearTimeout(saveNotesTimer)
   saveNotesTimer = setTimeout(() => {
-    fetch(`/games/${props.gameId}/notes`, {
+    fetch(`/api/games/${props.gameId}/notes`, {
       method: 'PUT',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({ player_id: props.playerId, notes: notesData })

--- a/frontend/src/components/GameDebug.vue
+++ b/frontend/src/components/GameDebug.vue
@@ -511,7 +511,7 @@ async function fetchDebug() {
       params.set('events_offset', d.agent_events.length)
     }
     const qs = params.toString()
-    const res = await fetch(`/games/${props.gameId}/debug${qs ? '?' + qs : ''}`)
+    const res = await fetch(`/api/games/${props.gameId}/debug${qs ? '?' + qs : ''}`)
     if (!res.ok) {
       const body = await res.json().catch(() => ({}))
       throw new Error(body.detail || `HTTP ${res.status}`)

--- a/frontend/src/components/Lobby.vue
+++ b/frontend/src/components/Lobby.vue
@@ -343,7 +343,7 @@ async function fetchUrlGame(gid) {
   urlGameError.value = ''
   urlGameState.value = null
   try {
-    const endpoint = props.urlGameType === 'holdem' ? `/holdem/games/${gid}` : `/games/${gid}`
+    const endpoint = props.urlGameType === 'holdem' ? `/api/holdem/games/${gid}` : `/api/games/${gid}`
     const res = await fetch(endpoint)
     if (!res.ok) {
       urlGameError.value = 'Game not found'
@@ -381,7 +381,7 @@ async function createGame() {
   try {
     if (selectedGame.value === 'holdem') {
       const buyInCents = Math.round(holdemBuyIn.value * 100)
-      const res = await fetch('/holdem/games', {
+      const res = await fetch('/api/holdem/games', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({
@@ -392,7 +392,7 @@ async function createGame() {
       const { game_id } = await res.json()
       await doJoinHoldem(game_id)
     } else {
-      const res = await fetch('/games', { method: 'POST' })
+      const res = await fetch('/api/games', { method: 'POST' })
       const { game_id } = await res.json()
       await doJoin(game_id)
     }
@@ -412,7 +412,7 @@ async function joinGame() {
 
 async function doJoin(gameId) {
   try {
-    const res = await fetch(`/games/${gameId}/join`, {
+    const res = await fetch(`/api/games/${gameId}/join`, {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({
@@ -426,7 +426,7 @@ async function doJoin(gameId) {
       return
     }
     const { player_id } = await res.json()
-    const stateRes = await fetch(`/games/${gameId}`)
+    const stateRes = await fetch(`/api/games/${gameId}`)
     const state = await stateRes.json()
     emit('game-joined', { gameId, playerId: player_id, state })
   } catch (e) {
@@ -436,7 +436,7 @@ async function doJoin(gameId) {
 
 async function doJoinHoldem(gameId) {
   try {
-    const res = await fetch(`/holdem/games/${gameId}/join`, {
+    const res = await fetch(`/api/holdem/games/${gameId}/join`, {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({ player_name: playerName.value })
@@ -447,7 +447,7 @@ async function doJoinHoldem(gameId) {
       return
     }
     const { player_id } = await res.json()
-    const stateRes = await fetch(`/holdem/games/${gameId}`)
+    const stateRes = await fetch(`/api/holdem/games/${gameId}`)
     const state = await stateRes.json()
     emit('game-joined', { gameId, playerId: player_id, state, gameType: 'holdem' })
   } catch (e) {
@@ -459,7 +459,7 @@ async function observeGame() {
   error.value = ''
   const gid = joinGameId.value.trim().toUpperCase()
   try {
-    const res = await fetch(`/games/${gid}`)
+    const res = await fetch(`/api/games/${gid}`)
     if (!res.ok) {
       error.value = 'Game not found'
       return

--- a/frontend/src/components/PokerWaitingRoom.vue
+++ b/frontend/src/components/PokerWaitingRoom.vue
@@ -134,7 +134,7 @@ async function addAgent() {
   error.value = ''
   addingAgent.value = true
   try {
-    const res = await fetch(`/holdem/games/${props.gameId}/add_agent`, { method: 'POST' })
+    const res = await fetch(`/api/holdem/games/${props.gameId}/add_agent`, { method: 'POST' })
     if (!res.ok) {
       const data = await res.json()
       error.value = data.detail ?? 'Failed to add agent'
@@ -149,7 +149,7 @@ async function addAgent() {
 async function startGame() {
   error.value = ''
   try {
-    const res = await fetch(`/holdem/games/${props.gameId}/start`, { method: 'POST' })
+    const res = await fetch(`/api/holdem/games/${props.gameId}/start`, { method: 'POST' })
     if (!res.ok) {
       const data = await res.json()
       error.value = data.detail ?? 'Failed to start'

--- a/frontend/src/components/WaitingRoom.vue
+++ b/frontend/src/components/WaitingRoom.vue
@@ -144,7 +144,7 @@ async function addAgent(agentType) {
   error.value = ''
   addingAgent.value = true
   try {
-    const res = await fetch(`/games/${props.gameId}/add_agent`, {
+    const res = await fetch(`/api/games/${props.gameId}/add_agent`, {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({ agent_type: agentType })
@@ -163,7 +163,7 @@ async function addAgent(agentType) {
 async function startGame() {
   error.value = ''
   try {
-    const res = await fetch(`/games/${props.gameId}/start`, { method: 'POST' })
+    const res = await fetch(`/api/games/${props.gameId}/start`, { method: 'POST' })
     if (!res.ok) {
       const data = await res.json()
       error.value = data.detail ?? 'Failed to start'

--- a/frontend/src/composables/useWebSocket.ts
+++ b/frontend/src/composables/useWebSocket.ts
@@ -17,7 +17,7 @@ export function useWebSocket(gameId: string, playerId: string): UseWebSocketRetu
 
   function connect() {
     const proto = location.protocol === 'https:' ? 'wss' : 'ws'
-    ws = new WebSocket(`${proto}://${location.host}/ws/${gameId}/${playerId}`)
+    ws = new WebSocket(`${proto}://${location.host}/api/ws/${gameId}/${playerId}`)
 
     ws.onopen = () => {
       connected.value = true

--- a/frontend/vite.config.js
+++ b/frontend/vite.config.js
@@ -2,8 +2,6 @@ import { defineConfig } from 'vite'
 import vue from '@vitejs/plugin-vue'
 
 const backendUrl = process.env.BACKEND_URL || 'http://localhost:8000'
-const backendWsUrl = backendUrl.replace(/^http/, 'ws')
-
 export default defineConfig({
   plugins: [vue()],
   build: {
@@ -12,11 +10,7 @@ export default defineConfig({
   },
   server: {
     proxy: {
-      '/games': backendUrl,
-      '/board': backendUrl,
-      '/holdem/games': backendUrl,
-      '/admin/games': backendUrl,
-      '/ws': { target: backendWsUrl, ws: true }
+      '/api': { target: backendUrl, ws: true }
     }
   }
 })

--- a/k8s/backend.yaml
+++ b/k8s/backend.yaml
@@ -48,7 +48,7 @@ spec:
               cpu: "500m"
           readinessProbe:
             httpGet:
-              path: /healthz
+              path: /api/healthz
               port: 8000
             initialDelaySeconds: 5
             periodSeconds: 10

--- a/scripts/git_history_screenshot_worker.js
+++ b/scripts/git_history_screenshot_worker.js
@@ -105,11 +105,11 @@ async function screenshotClueViaUI(browser, label, outputDir) {
     if (gameIdMatch) {
       const gameId = gameIdMatch[1];
       // Check player count via API
-      const state = await tryFetch(`${BACKEND_URL}/games/${gameId}`);
+      const state = await tryFetch(`${BACKEND_URL}/api/games/${gameId}`);
       const playerCount = state?.players?.length || 0;
       if (playerCount < 3) {
         for (let i = playerCount; i < 3; i++) {
-          await tryFetch(`${BACKEND_URL}/games/${gameId}/join`, {
+          await tryFetch(`${BACKEND_URL}/api/games/${gameId}/join`, {
             method: "POST",
             headers: { "Content-Type": "application/json" },
             body: JSON.stringify({ player_name: `Bot${i}` }),
@@ -170,7 +170,7 @@ async function screenshotHoldemViaUI(browser, label, outputDir) {
   console.log("Screenshotting Hold'em game (UI-driven)...");
 
   // Check if holdem endpoint exists at this commit
-  const check = await tryFetch(`${BACKEND_URL}/holdem/games`, { method: "POST" });
+  const check = await tryFetch(`${BACKEND_URL}/api/holdem/games`, { method: "POST" });
   if (!check || !check.game_id) {
     console.log("  SKIP: Hold'em not available at this commit");
     return;
@@ -232,11 +232,11 @@ async function screenshotHoldemViaUI(browser, label, outputDir) {
     const gameIdMatch = currentUrl.match(/\/holdem\/([A-Z0-9]+)/i);
     if (gameIdMatch) {
       const gameId = gameIdMatch[1];
-      const state = await tryFetch(`${BACKEND_URL}/holdem/games/${gameId}`);
+      const state = await tryFetch(`${BACKEND_URL}/api/holdem/games/${gameId}`);
       const playerCount = state?.players?.length || 0;
       if (playerCount < 3) {
         for (let j = playerCount; j < 3; j++) {
-          await tryFetch(`${BACKEND_URL}/holdem/games/${gameId}/join`, {
+          await tryFetch(`${BACKEND_URL}/api/holdem/games/${gameId}/join`, {
             method: "POST",
             headers: { "Content-Type": "application/json" },
             body: JSON.stringify({ player_name: `Bot${j}` }),

--- a/scripts/live_ws_test.py
+++ b/scripts/live_ws_test.py
@@ -94,7 +94,7 @@ async def run_live_test(base_url: str, num_agents: int = 3):
 
     # Step 1: Health check
     try:
-        resp = await http.get("/healthz")
+        resp = await http.get("/api/healthz")
         assert resp.status_code == 200, f"Health check failed: {resp.status_code}"
         print("[OK] Server is healthy")
     except Exception as e:
@@ -106,7 +106,7 @@ async def run_live_test(base_url: str, num_agents: int = 3):
         return False
 
     # Step 2: Create game
-    resp = await http.post("/games")
+    resp = await http.post("/api/games")
     assert resp.status_code == 201
     game_id = resp.json()["game_id"]
     print(f"[OK] Created game: {game_id}")
@@ -116,7 +116,7 @@ async def run_live_test(base_url: str, num_agents: int = 3):
     player_characters: dict[str, str] = {}
     for i in range(num_agents):
         resp = await http.post(
-            f"/games/{game_id}/join",
+            f"/api/games/{game_id}/join",
             json={"player_name": f"Bot-{i}", "player_type": "agent"},
         )
         assert resp.status_code == 200
@@ -143,7 +143,7 @@ async def run_live_test(base_url: str, num_agents: int = 3):
             pass
 
     for pid in pids:
-        ws = await websockets.connect(f"{ws_base}/ws/{game_id}/{pid}")
+        ws = await websockets.connect(f"{ws_base}/api/ws/{game_id}/{pid}")
         ws_connections[pid] = ws
     print(f"[OK] WebSocket connections established for all {num_agents} agents")
 
@@ -162,7 +162,7 @@ async def run_live_test(base_url: str, num_agents: int = 3):
     print("[OK] All agents received initial game_state via WebSocket")
 
     # Step 5: Start game
-    resp = await http.post(f"/games/{game_id}/start")
+    resp = await http.post(f"/api/games/{game_id}/start")
     assert resp.status_code == 200
     print(f"[OK] Game started, first turn: {resp.json()['whose_turn']}")
 
@@ -198,7 +198,7 @@ async def run_live_test(base_url: str, num_agents: int = 3):
     start_time = time.time()
 
     # Fetch initial state as a GameState model
-    resp = await http.get(f"/games/{game_id}")
+    resp = await http.get(f"/api/games/{game_id}")
     game_state = GameState.model_validate(resp.json())
 
     while game_state.status == "playing" and actions_taken < MAX_TURNS:
@@ -213,7 +213,7 @@ async def run_live_test(base_url: str, num_agents: int = 3):
                 pending.suggesting_player_id,
             )
             resp = await http.post(
-                f"/games/{game_id}/action",
+                f"/api/games/{game_id}/action",
                 json={"player_id": pid, "action": {"type": "show_card", "card": card}},
             )
             assert resp.status_code == 200, f"show_card failed: {resp.text}"
@@ -244,7 +244,7 @@ async def run_live_test(base_url: str, num_agents: int = 3):
             )
             action = await agent.decide_action(game_state, player_state)
             resp = await http.post(
-                f"/games/{game_id}/action",
+                f"/api/games/{game_id}/action",
                 json={"player_id": pid, "action": action},
             )
             assert (
@@ -275,7 +275,7 @@ async def run_live_test(base_url: str, num_agents: int = 3):
         await asyncio.sleep(0.05)
 
         # Refresh game state
-        resp = await http.get(f"/games/{game_id}")
+        resp = await http.get(f"/api/games/{game_id}")
         game_state = GameState.model_validate(resp.json())
         actions_taken += 1
 

--- a/tests/playwright/take_screenshots.js
+++ b/tests/playwright/take_screenshots.js
@@ -38,26 +38,26 @@ async function main() {
   // ===== Create holdem game and players via API =====
   console.log("Setting up holdem game...");
   const { game_id: gameId } = await (
-    await fetch(`${BACKEND_URL}/holdem/games`, { method: "POST" })
+    await fetch(`${BACKEND_URL}/api/holdem/games`, { method: "POST" })
   ).json();
   console.log("  Game:", gameId);
 
   const p1 = await (
-    await fetch(`${BACKEND_URL}/holdem/games/${gameId}/join`, {
+    await fetch(`${BACKEND_URL}/api/holdem/games/${gameId}/join`, {
       method: "POST",
       headers: { "Content-Type": "application/json" },
       body: JSON.stringify({ player_name: "Alice", buy_in: 1000 }),
     })
   ).json();
   const p2 = await (
-    await fetch(`${BACKEND_URL}/holdem/games/${gameId}/join`, {
+    await fetch(`${BACKEND_URL}/api/holdem/games/${gameId}/join`, {
       method: "POST",
       headers: { "Content-Type": "application/json" },
       body: JSON.stringify({ player_name: "Bob", buy_in: 1000 }),
     })
   ).json();
   const p3 = await (
-    await fetch(`${BACKEND_URL}/holdem/games/${gameId}/join`, {
+    await fetch(`${BACKEND_URL}/api/holdem/games/${gameId}/join`, {
       method: "POST",
       headers: { "Content-Type": "application/json" },
       body: JSON.stringify({ player_name: "Charlie", buy_in: 1500 }),
@@ -113,7 +113,7 @@ async function main() {
   } else {
     console.log("  Starting via API...");
     const startResp = await fetch(
-      `${BACKEND_URL}/holdem/games/${gameId}/start`,
+      `${BACKEND_URL}/api/holdem/games/${gameId}/start`,
       {
         method: "POST",
         headers: { "Content-Type": "application/json" },


### PR DESCRIPTION
## Summary
This PR adds a consistent `/api` prefix to all backend API routes and updates all frontend code, scripts, and configuration to use the new paths. This improves API organization by clearly separating API endpoints from other potential routes.

## Key Changes

### Backend (main.py)
- Added `/api` prefix to all 30+ route endpoints across:
  - Game management routes (`/games`, `/games/{game_id}`, etc.)
  - Health check (`/healthz`)
  - Admin routes (`/admin/games`)
  - Board data (`/board`)
  - WebSocket endpoints (`/ws`)
  - Chat endpoints
  - Hold'em game routes (`/holdem/games`)
  - Agent debug and trace routes

### Frontend Configuration
- **nginx.conf**: Consolidated multiple location blocks into a single `/api` proxy that handles all API traffic and WebSocket upgrades
- **vite.config.js**: Simplified dev server proxy configuration to use a single `/api` target with WebSocket support

### Frontend Components & Scripts
- Updated all `fetch()` calls across Vue components to use `/api` prefixed paths:
  - `App.vue`: Board data, WebSocket connections, game state fetches
  - `Lobby.vue`: Game creation and joining
  - `GameBoard.vue`: Notes saving
  - `GameDebug.vue`: Debug info fetching
  - `WaitingRoom.vue`: Agent addition and game start
  - `PokerWaitingRoom.vue`: Hold'em specific endpoints
  - `AdminGames.vue`: Admin game listing and details
  - `useWebSocket.ts`: WebSocket connection composable

### Scripts & Tests
- **agent_runner.py**: Updated WebSocket and HTTP API paths
- **live_ws_test.py**: Updated all test endpoint paths
- **test_ws_e2e.py**: Updated test helper functions
- **git_history_screenshot_worker.js**: Updated screenshot generation API calls
- **take_screenshots.js**: Updated Playwright test API calls

### Infrastructure
- **k8s/backend.yaml**: Updated readiness probe path to `/api/healthz`

## Implementation Details
- All route changes are backward-incompatible; clients must update to use `/api` prefix
- The nginx configuration now uses a single catch-all `/api` location that handles both REST and WebSocket traffic
- The Vite dev server proxy is simplified to a single rule with WebSocket support enabled
- No functional changes to the API logic itself—this is purely a routing reorganization

https://claude.ai/code/session_01Fv3qWJJoUuqDxooVGiwVfb