### PR TITLE
Remove unused suspectStyle function and inline styling

### DIFF
--- a/frontend/src/components/DetectiveNotes.vue
+++ b/frontend/src/components/DetectiveNotes.vue
@@ -7,7 +7,7 @@
       <div v-for="card in SUSPECTS" :key="card" class="note-row" :class="noteClass(card)" @click="cycleNote(card)">
         <img v-if="CARD_IMAGES[card]" :src="CARD_IMAGES[card]" :alt="card" class="note-thumb"
           :style="{ borderColor: CHARACTER_COLORS[card]?.bg || '#666' }" />
-        <span class="note-card" :style="suspectStyle(card)">{{ card }}</span>
+        <span class="note-card">{{ card }}</span>
         <span class="note-mark" :class="{ 'has-tooltip': notes[card] === 'seen' && shownByMap[card] }">
           {{ noteMark(card) }}
           <span v-if="notes[card] === 'seen' && shownByMap[card]" class="note-tooltip">Shown by {{ shownByMap[card]
@@ -115,15 +115,6 @@ function emitNotesChanged() {
 
 // Watch for any notes changes and emit
 watch(notes, () => emitNotesChanged(), { deep: true })
-
-function suspectStyle(card) {
-  const state = notes[card] ?? ''
-  if (state === 'have' || state === 'no' || state === 'seen') return {}
-  const color = CHARACTER_COLORS[card]?.name || CHARACTER_COLORS[card]?.bg
-  if (!color) return {}
-  // Default and 'maybe' states show the suspect's color
-  return { color }
-}
 
 function noteMark(card) {
   const state = notes[card] ?? ''


### PR DESCRIPTION
## Summary
Removed the `suspectStyle()` function and its associated inline style binding from the suspect note card element in the DetectiveNotes component.

## Changes
- Removed the `:style="suspectStyle(card)"` binding from the note card span element
- Deleted the `suspectStyle()` function that conditionally applied color styling based on note state
- The function was applying suspect character colors for 'default' and 'maybe' states, but this styling is no longer needed

## Details
The `suspectStyle()` function was returning an empty object for 'have', 'no', and 'seen' states, and only applying color styling for other states. By removing this function and its binding, the component now renders note cards without dynamic color styling, simplifying the component logic while maintaining all other functionality.

https://claude.ai/code/session_011ydh5w5PHFYViYyrq3Uk6A