### PR TITLE
Add action rejection handling with retry and fallback logic

### DIFF
--- a/backend/agent_runner.py
+++ b/backend/agent_runner.py
@@ -499,7 +499,55 @@ class AgentRunner:
         action_dict = action.model_dump()
         result = await self._send_action(game_id, player_id, action_dict)
         if isinstance(result, dict) and result.get("error"):
-            return
+            detail = result.get("detail", "")
+            agent.agent_trace(
+                "action_rejected",
+                status=result.get("status"),
+                detail=detail,
+                action=action_dict,
+            )
+            # Retry once with rejection detail for LLM agents, then fallback
+            if agent.agent_type == "llm":
+                logger.info(
+                    "Retrying action for %s in game %s after rejection: %s",
+                    player_id, game_id, detail,
+                )
+                try:
+                    action = await agent.decide_action(
+                        game_state, player_state, rejection_detail=detail
+                    )
+                except Exception:
+                    logger.exception(
+                        "Agent %s retry failed in game %s", player_id, game_id
+                    )
+                    return
+                action_dict = action.model_dump()
+                result = await self._send_action(game_id, player_id, action_dict)
+                if isinstance(result, dict) and result.get("error"):
+                    agent.agent_trace(
+                        "action_rejected_retry_failed",
+                        detail=result.get("detail", ""),
+                        action=action_dict,
+                    )
+                    # Fall back to rule-based agent
+                    logger.warning(
+                        "Retry also rejected for %s in game %s, using fallback",
+                        player_id, game_id,
+                    )
+                    fallback_action = await agent._fallback.decide_action(
+                        game_state, player_state
+                    )
+                    agent.agent_trace(
+                        "fallback_after_rejection",
+                        action=fallback_action.model_dump(),
+                    )
+                    action = fallback_action
+                    action_dict = action.model_dump()
+                    result = await self._send_action(game_id, player_id, action_dict)
+                    if isinstance(result, dict) and result.get("error"):
+                        return
+            else:
+                return
 
         await agent.save_knowledge()
 

--- a/backend/app/games/clue/agents.py
+++ b/backend/app/games/clue/agents.py
@@ -2004,7 +2004,6 @@ class LLMAgent(BaseAgent):
         game_state: GameState,
         player_state: PlayerState,
         errors: int = 0,
-        rejection_detail: str | None = None,
     ) -> GameAction:
         # Flush any inference notifications accumulated since last decision
         await self._flush_pending_inferences()

--- a/backend/app/games/clue/agents.py
+++ b/backend/app/games/clue/agents.py
@@ -1731,6 +1731,13 @@ class LLMAgent(BaseAgent):
 
         effective_model = model or self.model
 
+        self.agent_trace(
+            "llm_request",
+            model=effective_model,
+            system_prompt=_clip_text(system_prompt),
+            user_prompt=_clip_text(user_prompt),
+        )
+
         headers = {
             "Authorization": f"Bearer {self.api_key}",
             "Content-Type": "application/json",
@@ -1890,6 +1897,11 @@ class LLMAgent(BaseAgent):
             lines.append('  Roll dice: {"type": "roll"}')
         if "move" in available:
             lines.append('  Move: {"type": "move", "room": "<room name>"}')
+            player_current_room = current_room.get(player_id)
+            if player_current_room:
+                lines.append(
+                    f"    NOTE: You CANNOT re-enter {player_current_room} (the room you are already in). Choose a different room."
+                )
         if "suggest" in available:
             room = current_room.get(player_id, "")
             lines.append(
@@ -1988,7 +2000,11 @@ class LLMAgent(BaseAgent):
     # ------------------------------------------------------------------
 
     async def decide_action(
-        self, game_state: GameState, player_state: PlayerState, errors: int = 0
+        self,
+        game_state: GameState,
+        player_state: PlayerState,
+        errors: int = 0,
+        rejection_detail: str | None = None,
     ) -> GameAction:
         # Flush any inference notifications accumulated since last decision
         await self._flush_pending_inferences()
@@ -2044,6 +2060,11 @@ class LLMAgent(BaseAgent):
             personality=personality,
         )
         user_prompt = self._build_action_prompt(game_state, player_state)
+        if rejection_detail:
+            user_prompt += (
+                f"\n\nIMPORTANT: Your previous action was REJECTED by the server: "
+                f"{rejection_detail}\nChoose a DIFFERENT action."
+            )
         response_text = await self._call_llm(system_prompt, user_prompt)
 
         if response_text is not None:
@@ -2056,8 +2077,8 @@ class LLMAgent(BaseAgent):
                     # Stash chat for generate_chat() to return later
                     if llm_chat and isinstance(llm_chat, str):
                         self._pending_chat = llm_chat
-                    # Save memory entry if provided
-                    if llm_memory and isinstance(llm_memory, str):
+                    # Save memory entry only on end_turn
+                    if llm_memory and isinstance(llm_memory, str) and parsed.get("type") == "end_turn":
                         await self._save_memory_entry(llm_memory.strip())
                     # Track rooms for suggestion
                     if parsed.get("type") == "suggest":

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -1180,7 +1180,62 @@ async def _run_agent_loop(game_id: str):
                         name = _player_name(state, pid) if state else pid
                         await _broadcast_chat(game_id, f"{name}: {chat_msg}", pid)
 
-                result = await _execute_action(game_id, pid, action)
+                try:
+                    result = await _execute_action(game_id, pid, action)
+                except ValueError as exc:
+                    detail = str(exc)
+                    agent.agent_trace(
+                        "action_rejected",
+                        status=400,
+                        detail=detail,
+                        action=action_d,
+                    )
+                    # Retry once with rejection detail for LLM agents
+                    if agent.agent_type == "llm":
+                        logger.info(
+                            "Retrying action for %s in game %s after rejection: %s",
+                            pid, game_id, detail,
+                        )
+                        try:
+                            action = await agent.decide_action(
+                                state, player_state, rejection_detail=detail
+                            )
+                            action_d = action.model_dump()
+                            result = await _execute_action(game_id, pid, action)
+                        except (ValueError, Exception) as retry_exc:
+                            agent.agent_trace(
+                                "action_rejected_retry_failed",
+                                detail=str(retry_exc),
+                                action=action_d,
+                            )
+                            logger.warning(
+                                "Retry also failed for %s in game %s, using fallback",
+                                pid, game_id,
+                            )
+                            try:
+                                fallback_action = await agent._fallback.decide_action(
+                                    state, player_state
+                                )
+                                agent.agent_trace(
+                                    "fallback_after_rejection",
+                                    action=fallback_action.model_dump(),
+                                )
+                                action = fallback_action
+                                action_d = action.model_dump()
+                                result = await _execute_action(game_id, pid, action)
+                            except Exception:
+                                logger.exception(
+                                    "Fallback also failed for %s in game %s",
+                                    pid, game_id,
+                                )
+                                continue
+                    else:
+                        logger.warning(
+                            "Action rejected for non-LLM agent %s in game %s: %s",
+                            pid, game_id, detail,
+                        )
+                        continue
+
                 await agent.save_knowledge()
 
                 # Broadcast personality chat after the action (non-suggest)

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -1202,7 +1202,7 @@ async def _run_agent_loop(game_id: str):
                             )
                             action_d = action.model_dump()
                             result = await _execute_action(game_id, pid, action)
-                        except (ValueError, Exception) as retry_exc:
+                        except Exception as retry_exc:
                             agent.agent_trace(
                                 "action_rejected_retry_failed",
                                 detail=str(retry_exc),


### PR DESCRIPTION
## Summary
Implement comprehensive error handling for rejected game actions with automatic retry and fallback mechanisms. When an LLM agent's action is rejected, the system now attempts to recover by retrying with rejection details or falling back to a rule-based agent, improving game resilience and player experience.

## Key Changes

- **Action rejection handling in main game loop** (`backend/app/main.py`):
  - Wrap `_execute_action()` in try-catch to handle `ValueError` exceptions
  - For LLM agents: retry action with rejection detail passed to `decide_action()`
  - If retry fails, fall back to the agent's rule-based fallback strategy
  - For non-LLM agents: skip the turn on rejection
  - Log all rejection events and recovery attempts

- **Action rejection handling in agent runner** (`backend/agent_runner.py`):
  - Mirror rejection handling logic in `_handle_your_turn()` method
  - Extract error details from server response and pass to agent tracing
  - Implement same retry-then-fallback pattern for consistency
  - Gracefully handle fallback failures

- **LLM agent improvements** (`backend/app/games/clue/agents.py`):
  - Add LLM request tracing with model and prompt information
  - Enhance move action prompt with explicit constraint: prevent re-entering current room
  - Add `rejection_detail` parameter to `decide_action()` method
  - Append rejection context to user prompt when retrying after rejection
  - Fix memory saving to only occur on `end_turn` actions (not all actions)

## Implementation Details

- Rejection handling follows a three-tier recovery strategy:
  1. **Retry**: LLM agent gets another chance with rejection reason
  2. **Fallback**: If retry fails, use rule-based agent for safe action
  3. **Skip**: If fallback fails, skip the turn gracefully

- Agent tracing captures rejection lifecycle: `action_rejected` → `action_rejected_retry_failed` → `fallback_after_rejection`

- Room constraint prevents invalid moves by explicitly informing the LLM it cannot stay in its current room

- Memory entries are now only persisted on turn-ending actions, preventing spurious memory from rejected attempts

https://claude.ai/code/session_014smjNUMfmc7oiRToXx7SMs