### PR TITLE
Allow end_turn action to be a no-op when not player's turn

### DIFF
--- a/backend/app/games/clue/game.py
+++ b/backend/app/games/clue/game.py
@@ -515,8 +515,20 @@ class ClueGame:
         if state.status != "playing":
             raise ValueError("Game is not in progress")
 
-        if not isinstance(action, ShowCardAction) and state.whose_turn != player_id:
+        if not isinstance(action, (ShowCardAction, EndTurnAction)) and state.whose_turn != player_id:
             raise ValueError("It is not your turn")
+
+        # end_turn is always allowed: no-op if not your turn, force-finish if
+        # it is (even when not in the available list).  Agents may send this
+        # while cleaning up.
+        if isinstance(action, EndTurnAction):
+            if state.whose_turn != player_id:
+                # Not this player's turn — silently succeed as a no-op.
+                next_pid = state.whose_turn
+                return EndTurnResult(player_id=player_id, next_player_id=next_pid)
+            # It *is* their turn — skip the available-actions check and just
+            # end the turn (handles lingering end_turn after suggest, etc.).
+            return await self._handle_end_turn(state, player_id)
 
         available = self.get_available_actions(player_id, state)
         if action.type not in available:

--- a/backend/tests/test_game.py
+++ b/backend/tests/test_game.py
@@ -336,7 +336,22 @@ async def test_cannot_act_out_of_turn(game: ClueGame):
 
     not_their_turn = "P2" if state.whose_turn == "P1" else "P1"
     with pytest.raises(ValueError, match="not your turn"):
-        await game.process_action(not_their_turn, {"type": "end_turn"})
+        await game.process_action(not_their_turn, {"type": "roll"})
+
+
+@pytest.mark.asyncio
+async def test_end_turn_noop_when_not_your_turn(game: ClueGame):
+    """end_turn from the wrong player is a silent no-op, not an error."""
+    await _add_two_players(game)
+    state = await game.start()
+
+    current = state.whose_turn
+    not_their_turn = "P2" if current == "P1" else "P1"
+    result = await game.process_action(not_their_turn, {"type": "end_turn"})
+    assert result.type == "end_turn"
+    # Turn should NOT have advanced
+    refreshed = await game.get_state()
+    assert refreshed.whose_turn == current
 
 
 @pytest.mark.asyncio
@@ -539,7 +554,7 @@ async def test_cannot_end_turn_while_pending_show_card(game: ClueGame):
     )
     assert result.pending_show_by == other_id
 
-    with pytest.raises(ValueError, match="not available at this time"):
+    with pytest.raises(ValueError, match="Cannot end turn while waiting"):
         await game.process_action(whose_turn, {"type": "end_turn"})
 
 


### PR DESCRIPTION
## Summary
Modified the game action processing logic to treat `end_turn` actions as silent no-ops when sent by a player who is not currently taking their turn, rather than raising an error. This allows agents and clients to safely send cleanup `end_turn` actions without needing to track whose turn it is.

## Key Changes
- **Action validation**: `EndTurnAction` is now excluded from the turn-check validation, allowing it to be processed regardless of whose turn it is
- **end_turn handling**: When a player sends `end_turn` but it's not their turn, the action succeeds silently without advancing the turn
- **Force-finish support**: When it is the player's turn, `end_turn` now bypasses the available-actions check, allowing it to force-finish a turn even when not in the available list (e.g., after a suggest action)
- **Test updates**: 
  - Changed `test_cannot_act_out_of_turn` to test with `roll` action instead of `end_turn` (since `end_turn` is now allowed out-of-turn)
  - Added new `test_end_turn_noop_when_not_your_turn` to verify the no-op behavior
  - Updated error message expectation in `test_cannot_end_turn_while_pending_show_card` to match new validation message

## Implementation Details
The `end_turn` action now has special handling in `process_action()`:
1. It bypasses the initial turn validation check
2. If not the current player's turn, it returns immediately with a success result (no-op)
3. If it is the current player's turn, it skips the available-actions check and directly calls `_handle_end_turn()` to force-finish the turn

This design allows agents to safely send `end_turn` during cleanup without errors while still properly ending turns when appropriate.

https://claude.ai/code/session_01Aj1gLiMo8vrdSegF6keMhW