### PR TITLE
Fix Clue game mobile width issues and add responsive tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -215,3 +215,7 @@ __marimo__/
 
 mage-output/
 dump.rdb
+
+# Playwright
+screenshots/
+test-results/

--- a/frontend/src/App.vue
+++ b/frontend/src/App.vue
@@ -875,5 +875,6 @@ body {
   margin: 0 auto;
   padding: 0.75rem;
   overflow-x: hidden;
+  box-sizing: border-box;
 }
 </style>

--- a/frontend/src/components/BoardMap.vue
+++ b/frontend/src/components/BoardMap.vue
@@ -637,13 +637,13 @@ function tokenStyle(token) {
 
 @media (max-width: 480px) {
   .board-map {
-    padding: 0 0.75rem;
+    padding: 0;
   }
 }
 
 .board-container {
   position: relative;
-  box-sizing: content-box;
+  box-sizing: border-box;
   width: 100%;
   max-width: 690px;
   margin: 0 auto;

--- a/frontend/src/components/GameBoard.vue
+++ b/frontend/src/components/GameBoard.vue
@@ -1766,7 +1766,7 @@ watch(
 
 .card-preview-frame {
   position: relative;
-  width: 260px;
+  width: min(260px, 70vw);
   aspect-ratio: 57 / 89;
   background: #f5f0e1;
   border: 3px solid #c8b88a;
@@ -1950,7 +1950,7 @@ watch(
 }
 
 .card-shown-banner-card.physical-card {
-  width: 180px;
+  width: min(180px, 50vw);
 }
 
 .card-shown-banner-card.physical-card .physical-card-image-frame {
@@ -2228,6 +2228,10 @@ watch(
     order: 3;
     flex-basis: 100%;
   }
+
+  .sidebar-column {
+    max-width: 100%;
+  }
 }
 
 @media (max-width: 500px) {
@@ -2240,9 +2244,38 @@ watch(
     font-size: 1.1rem;
   }
 
+  .header-left {
+    gap: 0.35rem;
+  }
+
   .header-right {
     gap: 0.4rem;
   }
+
+  .status-banner {
+    font-size: 0.82rem;
+    padding: 0.25rem 0.6rem;
+  }
+
+  .dice {
+    width: 24px;
+    height: 24px;
+    font-size: 0.8rem;
+  }
+
+  .hand-card {
+    width: 68px;
+    font-size: 0.65rem;
+  }
+
+  .physical-card-image-frame {
+    height: 50px;
+  }
+
+  .sidebar-panel {
+    padding: 0.5rem;
+  }
+
   .game-over-cards {
     gap: 0.75rem;
   }
@@ -2260,6 +2293,31 @@ watch(
   .legend-name,
   .legend-character {
     display: none;
+  }
+}
+
+@media (max-width: 390px) {
+  .header-left h1 {
+    font-size: 1rem;
+    letter-spacing: 0.1em;
+  }
+
+  .game-id-label {
+    display: none;
+  }
+
+  .hand-card {
+    width: 60px;
+    font-size: 0.6rem;
+  }
+
+  .card-hand {
+    gap: 0.3rem;
+  }
+
+  .status-banner {
+    font-size: 0.75rem;
+    padding: 0.2rem 0.5rem;
   }
 }
 </style>

--- a/tests/playwright/test_responsive.spec.js
+++ b/tests/playwright/test_responsive.spec.js
@@ -1,0 +1,117 @@
+// @ts-check
+const { test, expect } = require("@playwright/test");
+
+const SCREENSHOT_DIR = "./screenshots/responsive";
+
+const VIEWPORTS = {
+  "iphone-se": { width: 375, height: 667 },
+  "iphone-14": { width: 390, height: 844 },
+  "iphone-14-pro-max": { width: 430, height: 932 },
+  "pixel-7": { width: 412, height: 915 },
+  "ipad-mini": { width: 768, height: 1024 },
+  "ipad-pro": { width: 1024, height: 1366 },
+  desktop: { width: 1280, height: 900 },
+};
+
+test.describe("Responsive Layout - Clue Game", () => {
+  for (const [device, viewport] of Object.entries(VIEWPORTS)) {
+    test(`no horizontal overflow at ${device} (${viewport.width}x${viewport.height})`, async ({
+      browser,
+    }) => {
+      const context = await browser.newContext({ viewport });
+      const page = await context.newPage();
+
+      // --- Lobby ---
+      await page.goto("/");
+      await expect(page.locator("h1")).toContainText("Game Night", {
+        timeout: 10000,
+      });
+      await page.waitForTimeout(1000);
+
+      const lobbyOverflow = await page.evaluate(
+        () =>
+          document.documentElement.scrollWidth >
+          document.documentElement.clientWidth
+      );
+      await page.screenshot({
+        path: `${SCREENSHOT_DIR}/lobby-${device}.png`,
+        fullPage: true,
+      });
+      expect(lobbyOverflow, `Lobby overflows at ${device}`).toBe(false);
+
+      // --- Select Clue, create game ---
+      await page.locator(".game-card").first().click();
+      await page
+        .locator('input[placeholder="Your name"]')
+        .first()
+        .fill("TestPlayer");
+      await page
+        .locator('button:has-text("Start Game")')
+        .first()
+        .click();
+
+      // --- Waiting Room ---
+      await expect(
+        page.getByText("The Suspects Are Gathering")
+      ).toBeVisible({ timeout: 10000 });
+      await page.waitForTimeout(500);
+
+      const waitingOverflow = await page.evaluate(
+        () =>
+          document.documentElement.scrollWidth >
+          document.documentElement.clientWidth
+      );
+      await page.screenshot({
+        path: `${SCREENSHOT_DIR}/waiting-${device}.png`,
+        fullPage: true,
+      });
+      expect(waitingOverflow, `Waiting room overflows at ${device}`).toBe(
+        false
+      );
+
+      // --- Add agents & start game ---
+      const addAgentBtn = page
+        .getByRole("button", { name: "Add Agent" })
+        .first();
+      await addAgentBtn.click();
+      await expect(page.locator(".count-badge")).toContainText("2 / 6", {
+        timeout: 5000,
+      });
+      await addAgentBtn.click();
+      await expect(page.locator(".count-badge")).toContainText("3 / 6", {
+        timeout: 5000,
+      });
+
+      await page
+        .getByRole("button", { name: "Begin the Investigation" })
+        .click();
+      await expect(page.locator(".game-board").first()).toBeVisible({
+        timeout: 10000,
+      });
+      await expect(page.locator(".board-map")).toBeVisible();
+      await page.waitForTimeout(2000);
+
+      // --- Game Board ---
+      await page.screenshot({
+        path: `${SCREENSHOT_DIR}/gameboard-${device}.png`,
+        fullPage: true,
+      });
+
+      const gameOverflow = await page.evaluate(
+        () =>
+          document.documentElement.scrollWidth >
+          document.documentElement.clientWidth
+      );
+      expect(gameOverflow, `Game board overflows at ${device}`).toBe(false);
+
+      // Verify board fits within viewport
+      const boardWidth = await page.evaluate(() => {
+        const board = document.querySelector(".board-container");
+        return board ? board.getBoundingClientRect().width : 0;
+      });
+      expect(boardWidth).toBeLessThanOrEqual(viewport.width);
+
+      await context.close();
+    });
+  }
+});

--- a/tests/playwright/test_responsive_screenshots.js
+++ b/tests/playwright/test_responsive_screenshots.js
@@ -1,0 +1,181 @@
+const { chromium } = require("playwright-core");
+
+const BASE_URL = process.env.BASE_URL || "http://localhost:5173";
+const SCREENSHOT_DIR = process.env.SCREENSHOT_DIR || "./screenshots/responsive";
+const CHROME_PATH =
+  process.env.CHROME_PATH ||
+  "/root/.cache/ms-playwright/chromium-1194/chrome-linux/chrome";
+
+function sleep(ms) {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+const VIEWPORTS = {
+  "iphone-se": { width: 375, height: 667 },
+  "iphone-14": { width: 390, height: 844 },
+  "iphone-14-pro-max": { width: 430, height: 932 },
+  "pixel-7": { width: 412, height: 915 },
+  "ipad-mini": { width: 768, height: 1024 },
+  "ipad-pro": { width: 1024, height: 1366 },
+  desktop: { width: 1280, height: 900 },
+};
+
+async function main() {
+  const browser = await chromium.launch({
+    headless: true,
+    executablePath: CHROME_PATH,
+  });
+
+  const results = [];
+
+  for (const [device, viewport] of Object.entries(VIEWPORTS)) {
+    console.log(`\n=== ${device} (${viewport.width}x${viewport.height}) ===`);
+
+    const context = await browser.newContext({ viewport });
+    const page = await context.newPage();
+
+    try {
+      await page.goto(BASE_URL);
+      await sleep(2000);
+
+      // Click Clue game card
+      await page.locator(".game-card").first().click();
+      await sleep(1000);
+
+      // Create game
+      await page.locator('input[placeholder="Your name"]').first().fill("TestPlayer");
+      await page.locator('button:has-text("Start Game")').first().click();
+      await sleep(3000);
+
+      // Add agents & start
+      const addBtn = page.locator('button:has-text("Add Agent")').first();
+      await addBtn.click();
+      await sleep(1500);
+      await addBtn.click();
+      await sleep(1500);
+      await page.locator('button:has-text("Begin the Investigation")').click();
+      await sleep(5000);
+
+      // Measure with overflow-x removed temporarily
+      const m = await page.evaluate(() => {
+        // Temporarily remove overflow-x: hidden to see true content width
+        const html = document.documentElement;
+        const body = document.body;
+        const app = document.getElementById("clue-app");
+
+        const origHtml = html.style.overflowX;
+        const origBody = body.style.overflowX;
+        const origApp = app ? app.style.overflowX : "";
+
+        html.style.overflowX = "visible";
+        body.style.overflowX = "visible";
+        if (app) app.style.overflowX = "visible";
+
+        const trueScrollWidth = Math.max(
+          html.scrollWidth,
+          body.scrollWidth,
+          app ? app.scrollWidth : 0
+        );
+
+        // Find elements wider than viewport
+        const wideElements = [];
+        document.querySelectorAll("*").forEach((el) => {
+          const rect = el.getBoundingClientRect();
+          if (rect.width > window.innerWidth + 2) {
+            wideElements.push({
+              tag: el.tagName,
+              class: el.className.toString().substring(0, 60),
+              width: Math.round(rect.width),
+              left: Math.round(rect.left),
+              right: Math.round(rect.right),
+            });
+          }
+        });
+
+        // Restore
+        html.style.overflowX = origHtml;
+        body.style.overflowX = origBody;
+        if (app) app.style.overflowX = origApp;
+
+        // Specific element measurements
+        const mainLayout = document.querySelector(".main-layout");
+        const sidebar = document.querySelector(".sidebar-column");
+        const boardContainer = document.querySelector(".board-container");
+        const cardHand = document.querySelector(".card-hand");
+        const gameHeader = document.querySelector(".game-header");
+        const actionSection = document.querySelector(".action-section");
+        const suggestionForm = document.querySelector(".suggestion-form");
+        const detectiveNotes = document.querySelector(".detective-notes");
+
+        function measure(el) {
+          if (!el) return null;
+          const r = el.getBoundingClientRect();
+          return { width: Math.round(r.width), scrollWidth: el.scrollWidth, left: Math.round(r.left), right: Math.round(r.right) };
+        }
+
+        return {
+          viewportWidth: window.innerWidth,
+          trueScrollWidth,
+          overflow: trueScrollWidth > window.innerWidth,
+          overflowAmount: trueScrollWidth - window.innerWidth,
+          mainLayout: measure(mainLayout),
+          sidebar: measure(sidebar),
+          boardContainer: measure(boardContainer),
+          cardHand: measure(cardHand),
+          gameHeader: measure(gameHeader),
+          actionSection: measure(actionSection),
+          suggestionForm: measure(suggestionForm),
+          detectiveNotes: measure(detectiveNotes),
+          wideElements: wideElements.slice(0, 10),
+        };
+      });
+
+      await page.screenshot({ path: `${SCREENSHOT_DIR}/gameboard-${device}.png`, fullPage: true });
+
+      console.log(`  Viewport: ${m.viewportWidth}px`);
+      console.log(`  True scroll width: ${m.trueScrollWidth}px (overflow: ${m.overflow}, +${m.overflowAmount}px)`);
+      if (m.mainLayout) console.log(`  Main layout: ${JSON.stringify(m.mainLayout)}`);
+      if (m.boardContainer) console.log(`  Board container: ${JSON.stringify(m.boardContainer)}`);
+      if (m.cardHand) console.log(`  Card hand: ${JSON.stringify(m.cardHand)}`);
+      if (m.gameHeader) console.log(`  Game header: ${JSON.stringify(m.gameHeader)}`);
+      if (m.sidebar) console.log(`  Sidebar: ${JSON.stringify(m.sidebar)}`);
+      if (m.actionSection) console.log(`  Action section: ${JSON.stringify(m.actionSection)}`);
+      if (m.suggestionForm) console.log(`  Suggestion form: ${JSON.stringify(m.suggestionForm)}`);
+      if (m.detectiveNotes) console.log(`  Detective notes: ${JSON.stringify(m.detectiveNotes)}`);
+      if (m.wideElements.length > 0) {
+        console.log(`  Wide elements (>${m.viewportWidth}px):`);
+        for (const el of m.wideElements) {
+          console.log(`    ${el.tag}.${el.class}: ${el.width}px [${el.left} - ${el.right}]`);
+        }
+      }
+
+      if (m.overflow) {
+        results.push({ device, overflowAmount: m.overflowAmount, wideElements: m.wideElements });
+      }
+    } catch (err) {
+      console.log(`  ERROR: ${err.message}`);
+    }
+
+    await context.close();
+  }
+
+  await browser.close();
+
+  console.log("\n\n========== SUMMARY ==========");
+  if (results.length === 0) {
+    console.log("No overflow issues detected (even with overflow-x: hidden removed)!");
+  } else {
+    console.log(`Found ${results.length} viewport(s) with overflow:`);
+    for (const r of results) {
+      console.log(`\n  ${r.device}: overflow by ${r.overflowAmount}px`);
+      for (const el of r.wideElements) {
+        console.log(`    ${el.tag}.${el.class}: ${el.width}px`);
+      }
+    }
+  }
+}
+
+main().catch((err) => {
+  console.error("Error:", err);
+  process.exit(1);
+});


### PR DESCRIPTION
- Fix board container box-sizing from content-box to border-box to
  prevent subtle overflow on mobile viewports
- Add box-sizing: border-box to #clue-app root container
- Remove extra mobile padding on board-map that reduced usable space
- Use min() for card preview and shown-card widths to prevent overflow
  on narrow screens (260px -> min(260px, 70vw))
- Add mobile breakpoints at 500px and 390px for smaller UI elements:
  header, dice, hand cards, status banners, sidebar panels
- Hide case ID label on very small screens (<390px) to save space
- Add Playwright responsive test spec covering 7 viewport sizes
- Add standalone responsive screenshot script for visual debugging

https://claude.ai/code/session_018LeSFjwGz1PHfH9EKgdyaf