### PR TITLE
Extract PlayerPawn component from inline legend tokens

### DIFF
--- a/frontend/src/components/GameBoard.vue
+++ b/frontend/src/components/GameBoard.vue
@@ -84,8 +84,7 @@
             'observer-clickable': isObserver,
             'observer-selected': isObserver && observerPlayerState?.playerId === p.id
           }" @click.stop="onLegendClick(p)">
-            <span class="legend-token" :class="{ 'wanderer-token-legend': p.type === 'wanderer' }"
-              :style="tokenStyle(p)">{{ abbr(p.character) }}</span>
+            <PlayerPawn :character="p.character" :wanderer="p.type === 'wanderer'" />
             <span class="legend-name">{{ p.name }}</span>
             <span v-if="p.type !== 'wanderer' && p.character !== p.name" class="legend-character">{{ p.character }}</span>
             <span v-if="gameState?.current_room?.[p.id]" class="legend-room">{{
@@ -480,6 +479,7 @@ import ChatPanel from './ChatPanel.vue'
 import DetectiveNotes from './DetectiveNotes.vue'
 import AgentDebugPanel from './AgentDebugPanel.vue'
 import ThemeSwitcher from './ThemeSwitcher.vue'
+import PlayerPawn from './PlayerPawn.vue'
 import { useTheme } from '../composables/useTheme'
 import {
   SUSPECTS,
@@ -490,8 +490,6 @@ import {
   cardIcon,
   hasCardImage as _hasCardImage,
   cardImageUrl as _cardImageUrl,
-  abbr,
-  characterColors
 } from '../constants/clue'
 
 const { theme } = useTheme()
@@ -629,12 +627,6 @@ function playerName(pid) {
   return p ? p.name : pid
 }
 
-function tokenStyle(player) {
-  const { bg, text } = characterColors(player.character)
-  const style = { backgroundColor: bg, color: text }
-  if (player.type === 'wanderer') style.opacity = 0.5
-  return style
-}
 
 function cardCategory(card) {
   if (SUSPECTS.includes(card)) return 'card-suspect'
@@ -993,18 +985,6 @@ watch(
   padding: 0.5rem;
 }
 
-.legend-token {
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  width: 20px;
-  height: 20px;
-  border-radius: 50%;
-  font-size: 0.55rem;
-  font-weight: bold;
-  flex-shrink: 0;
-  box-shadow: 0 1px 3px rgba(0, 0, 0, 0.4);
-}
 
 .legend-name {
   font-weight: 600;
@@ -1043,9 +1023,6 @@ watch(
   opacity: 0.5;
 }
 
-.wanderer-token-legend {
-  border: 1.5px dashed rgba(255, 255, 255, 0.3);
-}
 
 .legend-wanderer-label {
   color: var(--text-faint);

--- a/frontend/src/components/PlayerPawn.vue
+++ b/frontend/src/components/PlayerPawn.vue
@@ -1,0 +1,71 @@
+<template>
+  <div class="player-pawn" :class="{
+    'has-image': !!imageSrc,
+    'wanderer-pawn': wanderer
+  }" :style="pawnStyle">
+    <img v-if="imageSrc" :src="imageSrc" :alt="character" class="pawn-portrait" />
+    <span v-else>{{ abbr(character) }}</span>
+  </div>
+</template>
+
+<script setup>
+import { computed } from 'vue'
+import { CARD_IMAGES, abbr, characterColors } from '../constants/clue'
+
+const props = defineProps({
+  character: { type: String, required: true },
+  size: { type: String, default: null },
+  wanderer: { type: Boolean, default: false }
+})
+
+const imageSrc = computed(() => CARD_IMAGES[props.character] || '')
+
+const pawnStyle = computed(() => {
+  const { bg, text } = characterColors(props.character)
+  const style = {
+    backgroundColor: bg,
+    color: text,
+    '--pawn-border': bg
+  }
+  if (props.size) {
+    style.width = props.size
+    style.height = props.size
+  }
+  if (props.wanderer) {
+    style.opacity = 0.5
+  }
+  return style
+})
+</script>
+
+<style scoped>
+.player-pawn {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 20px;
+  height: 20px;
+  border-radius: 50%;
+  font-size: 0.55rem;
+  font-weight: bold;
+  box-shadow: 0 1px 3px rgba(0, 0, 0, 0.4);
+  flex-shrink: 0;
+  overflow: hidden;
+}
+
+.player-pawn.has-image {
+  background: none !important;
+  border: 1.5px solid;
+  border-color: var(--pawn-border, rgba(255, 255, 255, 0.5));
+}
+
+.pawn-portrait {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+  object-position: center 15%;
+  border-radius: 50%;
+  display: block;
+  clip-path: circle(50%);
+}
+</style>


### PR DESCRIPTION
Create a reusable PlayerPawn.vue component that encapsulates character
pawn rendering (colored circle with abbreviation or portrait image).
Replace the inline legend-token markup in GameBoard.vue's player legend
section with the new component, removing the now-unused tokenStyle
function, characterColors/abbr imports, and .legend-token CSS.

https://claude.ai/code/session_01H3DtVDGoVw5k8JC6cYFGmF