### PR TITLE
Show suggestion details in sticky banner, including when no one can show a card

### DIFF
--- a/backend/app/games/clue/models.py
+++ b/backend/app/games/clue/models.py
@@ -281,6 +281,9 @@ class CardShownMessage(WSMessage):
     type: Literal["card_shown"] = "card_shown"
     shown_by: str
     card: str
+    suspect: str = ""
+    weapon: str = ""
+    room: str = ""
     available_actions: list[str] = Field(default_factory=list)
 
 

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -633,6 +633,9 @@ async def _execute_action(
             CardShownMessage(
                 shown_by=player_id,
                 card=result.card,
+                suspect=result.suspect,
+                weapon=result.weapon,
+                room=result.room,
                 available_actions=game.get_available_actions(
                     result.suggesting_player_id, state
                 ),

--- a/frontend/src/App.vue
+++ b/frontend/src/App.vue
@@ -424,11 +424,15 @@ function handleMessage(msg) {
         if (msg.weapon_positions) suggUpdate.weapon_positions = msg.weapon_positions
         if (msg.current_room) suggUpdate.current_room = msg.current_room
         gameState.value = { ...gameState.value, ...suggUpdate }
+        // If no one can show a card and this is our suggestion, show the banner
+        if (!msg.pending_show_by && msg.player_id === playerId.value) {
+          cardShown.value = { card: null, by: null, suspect: msg.suspect, weapon: msg.weapon, room: msg.room }
+        }
       }
       break
 
     case 'card_shown':
-      cardShown.value = { card: msg.card, by: msg.shown_by }
+      cardShown.value = { card: msg.card, by: msg.shown_by, suspect: msg.suspect, weapon: msg.weapon, room: msg.room }
       if (msg.available_actions) availableActions.value = msg.available_actions
       showCardRequest.value = null
       autoShowCardTimer.value = null

--- a/frontend/src/components/GameBoard.vue
+++ b/frontend/src/components/GameBoard.vue
@@ -155,8 +155,19 @@
           <div class="shown-card-notice">
             <span class="shown-card-icon">&#128065;</span>
             <div>
-              <strong>{{ playerName(cardShown.by) }}</strong> showed you:
-              <span class="shown-card-name">{{ cardShown.card }}</span>
+              <div v-if="cardShown.suspect" class="shown-card-suggestion">
+                You suggested:
+                <span class="highlight-suspect">{{ cardShown.suspect }}</span>,
+                <span class="highlight-weapon">{{ cardShown.weapon }}</span>,
+                <span class="highlight-room">{{ cardShown.room }}</span>
+              </div>
+              <template v-if="cardShown.card">
+                <strong>{{ playerName(cardShown.by) }}</strong> showed you:
+                <span class="shown-card-name">{{ cardShown.card }}</span>
+              </template>
+              <template v-else>
+                No one could show a card.
+              </template>
             </div>
             <button class="dismiss-btn" @click="$emit('dismiss-card-shown')">&times;</button>
           </div>
@@ -372,9 +383,17 @@
     <Teleport to="body">
       <div v-if="cardShown && !cardShownDismissedOnce" class="card-shown-overlay" @click="dismissCardShownOverlay">
         <div class="card-shown-banner" @click.stop>
-          <div class="card-shown-banner-label">Card Revealed</div>
-          <div class="card-shown-banner-from">{{ playerName(cardShown.by) }} showed you:</div>
-          <div class="card-shown-banner-card physical-card" :class="cardCategory(cardShown.card)">
+          <div class="card-shown-banner-label">{{ cardShown.card ? 'Card Revealed' : 'No One Could Show' }}</div>
+          <div v-if="cardShown.suspect" class="card-shown-banner-suggestion">
+            You suggested:
+            <span class="highlight-suspect">{{ cardShown.suspect }}</span>
+            with the
+            <span class="highlight-weapon">{{ cardShown.weapon }}</span>
+            in the
+            <span class="highlight-room">{{ cardShown.room }}</span>
+          </div>
+          <div v-if="cardShown.card" class="card-shown-banner-from">{{ playerName(cardShown.by) }} showed you:</div>
+          <div v-if="cardShown.card" class="card-shown-banner-card physical-card" :class="cardCategory(cardShown.card)">
             <div class="physical-card-header">
               <span class="physical-card-icon">{{ cardIcon(cardShown.card) }}</span>
               <span class="physical-card-title">{{ cardShown.card }}</span>
@@ -388,6 +407,7 @@
               <span class="physical-card-icon">{{ cardIcon(cardShown.card) }}</span>
             </div>
           </div>
+          <div v-else class="card-shown-banner-noshow">No one could disprove your suggestion!</div>
           <button class="card-shown-banner-dismiss" @click="dismissCardShownOverlay">Got it</button>
         </div>
       </div>
@@ -771,9 +791,9 @@ onUnmounted(() => {
 watch(
   () => props.cardShown,
   (shown) => {
-    if (shown?.card) {
+    if (shown) {
       cardShownDismissedOnce.value = false
-      if (notesRef.value) {
+      if (shown.card && notesRef.value) {
         notesRef.value.markCard(shown.card, 'seen', playerName(shown.by))
       }
     }
@@ -1940,9 +1960,27 @@ watch(
   border: 1px solid rgba(212, 168, 73, 0.2);
 }
 
+.card-shown-banner-suggestion {
+  font-size: 0.9rem;
+  color: #c8bca8;
+  margin-bottom: 0.25rem;
+}
+
+.card-shown-banner-noshow {
+  font-size: 1.1rem;
+  font-weight: 700;
+  color: #d4a849;
+  padding: 1rem;
+}
+
 .card-shown-banner-from {
   font-size: 1rem;
   color: #c8bca8;
+}
+
+.shown-card-suggestion {
+  font-size: 0.85rem;
+  margin-bottom: 0.25rem;
 }
 
 .card-shown-banner-card {


### PR DESCRIPTION
The card-shown banner now always displays the suggestion context (suspect,
weapon, room) so the player knows what was suggested. When no one can
disprove the suggestion, a banner is shown instead of only a chat message.

- Add suspect/weapon/room fields to CardShownMessage
- Set cardShown on suggestion_made when no one can show (for current player)
- Update overlay banner and sidebar panel to display suggestion context
- Handle both "card revealed" and "no one could show" banner variants

https://claude.ai/code/session_01UxZVBd76KebabGdzgX9hUP