### PR TITLE
Fix characters complaining about being dragged to a room they chose

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -611,7 +611,8 @@ async def _execute_action(
             )
 
         # "dragged_to_room" reaction — if the piece was physically moved
-        if moved_suspect_player:
+        # Skip if the player dragged themselves (they made the suggestion)
+        if moved_suspect_player and moved_suspect_player != player_id:
             dragged_msg = generate_character_chat(
                 suspect_character,
                 "dragged_to_room",


### PR DESCRIPTION
When a player suggests their own character, the "dragged_to_room" chat
message would fire even though the player initiated the move themselves.
Skip the complaint when the moved suspect is the same player who made
the suggestion.

https://claude.ai/code/session_01F3PK5Zvgrspkik6MmTasQc