### PR TITLE
Fix iPhone viewport issues with dvh units and viewport-fit=cover

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -2,7 +2,7 @@
 <html lang="en">
   <head>
     <meta charset="UTF-8" />
-    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover" />
     <title>Clue Board Game</title>
   </head>
   <body>

--- a/frontend/src/App.vue
+++ b/frontend/src/App.vue
@@ -862,8 +862,9 @@ setInterval(() => {
 }
 
 html, body {
-  overflow-x: hidden;
+  overflow-x: clip;
   width: 100%;
+  max-width: 100vw;
 }
 
 body {
@@ -884,7 +885,7 @@ body {
   max-width: 1080px;
   margin: 0 auto;
   padding: 0.75rem;
-  overflow-x: hidden;
+  overflow-x: clip;
   box-sizing: border-box;
 }
 </style>

--- a/frontend/src/App.vue
+++ b/frontend/src/App.vue
@@ -871,7 +871,13 @@ body {
   background: var(--bg-page);
   color: var(--text-primary);
   min-height: 100vh;
+  min-height: 100dvh;
   transition: background 0.3s, color 0.3s;
+  /* Safe area insets for notched/rounded-corner devices */
+  padding-top: env(safe-area-inset-top);
+  padding-bottom: env(safe-area-inset-bottom);
+  padding-left: env(safe-area-inset-left);
+  padding-right: env(safe-area-inset-right);
 }
 
 #clue-app {

--- a/frontend/src/components/AdminGames.vue
+++ b/frontend/src/components/AdminGames.vue
@@ -188,6 +188,7 @@ onMounted(fetchGames)
   font-family: 'Crimson Text', Georgia, serif;
   color: var(--text-primary);
   min-height: 100vh;
+  min-height: 100dvh;
 }
 
 .admin-header {

--- a/frontend/src/components/Lobby.vue
+++ b/frontend/src/components/Lobby.vue
@@ -480,6 +480,7 @@ async function observeGame() {
 .lobby {
   position: relative;
   min-height: 100vh;
+  min-height: 100dvh;
   overflow: hidden;
   font-family: 'DM Sans', system-ui, sans-serif;
   background: var(--bg-page);

--- a/frontend/src/components/PokerWaitingRoom.vue
+++ b/frontend/src/components/PokerWaitingRoom.vue
@@ -181,6 +181,7 @@ async function startGame() {
   font-family: 'Outfit', system-ui, sans-serif;
   color: var(--text);
   min-height: 100vh;
+  min-height: 100dvh;
   display: flex;
   align-items: center;
   justify-content: center;

--- a/frontend/src/components/WaitingRoom.vue
+++ b/frontend/src/components/WaitingRoom.vue
@@ -183,6 +183,7 @@ async function startGame() {
 .waiting-room {
   position: relative;
   min-height: 100vh;
+  min-height: 100dvh;
   overflow: hidden;
   font-family: 'Crimson Text', Georgia, serif;
   background: var(--bg-page);


### PR DESCRIPTION
iOS Safari's 100vh includes the area behind browser chrome, causing
white space at the bottom of the screen. This adds:
- viewport-fit=cover meta tag for safe area handling on notched devices
- dvh (dynamic viewport height) fallback on all 100vh declarations
- safe-area-inset padding on body for notched/rounded-corner devices

https://claude.ai/code/session_01V4gGH3ZAJ5gmK49cSdFBao