### PR TITLE
Remove _clip_text utility function and use full text in traces

### DIFF
--- a/backend/app/games/clue/agents.py
+++ b/backend/app/games/clue/agents.py
@@ -88,12 +88,6 @@ def _compute_room_distances(
     return results
 
 
-def _clip_text(value: str, limit: int = 1200) -> str:
-    """Return text clipped to a max length for safer log output."""
-    if len(value) <= limit:
-        return value
-    return f"{value[:limit]}... [truncated {len(value) - limit} chars]"
-
 
 # ---------------------------------------------------------------------------
 # Character personality chat templates
@@ -1765,8 +1759,8 @@ class LLMAgent(BaseAgent):
         self.agent_trace(
             "llm_request",
             model=effective_model,
-            system_prompt=_clip_text(system_prompt),
-            user_prompt=_clip_text(user_prompt),
+            system_prompt=system_prompt,
+            user_prompt=user_prompt,
         )
 
         headers = {
@@ -1830,11 +1824,11 @@ class LLMAgent(BaseAgent):
                     return parsed
                 except json.JSONDecodeError:
                     self.agent_trace(
-                        "json_parse_failed", method="substring", text=_clip_text(text)
+                        "json_parse_failed", method="substring", text=text
                     )
             else:
                 self.agent_trace(
-                    "json_parse_failed", reason="no_json_braces", text=_clip_text(text)
+                    "json_parse_failed", reason="no_json_braces", text=text
                 )
         return None
 
@@ -2126,7 +2120,7 @@ class LLMAgent(BaseAgent):
             else:
                 self.agent_trace(
                     "llm_json_parse_failed",
-                    response_preview=_clip_text(response_text),
+                    response_preview=response_text,
                 )
         else:
             self.agent_trace("llm_no_response")
@@ -2179,7 +2173,7 @@ class LLMAgent(BaseAgent):
             else:
                 self.agent_trace(
                     "llm_show_card_parse_failed",
-                    response_preview=_clip_text(response_text),
+                    response_preview=response_text,
                 )
 
         # Fallback


### PR DESCRIPTION
## Summary
Removed the `_clip_text()` utility function that was truncating text to 1200 characters for log output, and updated all call sites to pass the full text to trace logging instead.

## Changes
- Deleted the `_clip_text()` helper function from `backend/app/games/clue/agents.py`
- Updated 5 trace logging calls to remove `_clip_text()` wrapping:
  - `_call_llm()`: system_prompt and user_prompt parameters
  - `_parse_json_response()`: text parameter in two json_parse_failed traces
  - `decide_action()`: response_preview parameter in llm_json_parse_failed trace
  - `decide_show_card()`: response_preview parameter in llm_show_card_parse_failed trace

## Rationale
This change simplifies the codebase by removing the text truncation logic, allowing full context to be captured in trace logs. This enables better debugging and analysis of LLM interactions without losing information to arbitrary length limits.

https://claude.ai/code/session_016J7CjC6DCnFZqFj4ZG73zy