### PR TITLE
Fix end-turn timer starting while card-shown banner is visible

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -785,8 +785,14 @@ async def _execute_action(
     # Publish observation events to Redis for external agent runners
     await _publish_agent_event(game_id, player_id, action, result)
 
-    # Check if the current player should get an auto-end-turn timer
-    await _maybe_start_auto_end_timer(game_id)
+    # Check if the current player should get an auto-end-turn timer.
+    # Skip when the card-shown banner will be visible to the player — the
+    # frontend will call /ack_card_shown after the player dismisses it.
+    _banner_visible = isinstance(result, ShowCardResult) or (
+        isinstance(result, SuggestResult) and result.pending_show_by is None
+    )
+    if not _banner_visible:
+        await _maybe_start_auto_end_timer(game_id)
 
     return result
 
@@ -1826,6 +1832,25 @@ async def submit_action(game_id: str, req: ActionRequest):
     if state:
         response["available_actions"] = game.get_available_actions(req.player_id, state)
     return response
+
+
+@app.post("/api/clue/games/{game_id}/ack_card_shown")
+async def ack_card_shown(game_id: str, req: dict):
+    """Called when a player dismisses the card-shown banner.
+
+    Starts the auto-end-turn timer now that the player can see their actions.
+    """
+    player_id = req.get("player_id")
+    if not player_id:
+        raise HTTPException(status_code=400, detail="player_id required")
+    game = ClueGame(game_id, redis_client)
+    state = await game.get_state()
+    if not state or state.status != "playing":
+        return OkResponse()
+    # Only start the timer if it's actually this player's turn
+    if state.whose_turn == player_id:
+        await _maybe_start_auto_end_timer(game_id)
+    return OkResponse()
 
 
 # ---------------------------------------------------------------------------

--- a/frontend/src/App.vue
+++ b/frontend/src/App.vue
@@ -16,7 +16,7 @@
         :auto-show-card-timer="autoShowCardTimer" :reachable-rooms="reachableRooms"
         :reachable-positions="reachablePositions" :saved-notes="savedNotes" :agent-debug-data="agentDebugData"
         :observer-player-state="observerPlayerState" @action="sendAction" @send-chat="sendChat"
-        @dismiss-card-shown="cardShown = null" @select-player="onObserverSelectPlayer" />
+        @dismiss-card-shown="onDismissCardShown" @select-player="onObserverSelectPlayer" />
     </template>
 
     <!-- Texas Hold'em views -->
@@ -682,6 +682,16 @@ async function sendAction(action) {
       // rely on WS updates
     }
   }
+}
+
+function onDismissCardShown() {
+  cardShown.value = null
+  // Tell the backend the banner is dismissed so it can start the auto-end timer
+  fetch(`/api/clue/games/${gameId.value}/ack_card_shown`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ player_id: playerId.value })
+  })
 }
 
 async function sendChat(text) {


### PR DESCRIPTION
The auto-end-turn timer was starting immediately after a show_card or no-one-can-show suggestion result, while the card-shown banner overlay was still blocking player interaction. Players would lose timer seconds reading the revealed card.

Backend: skip _maybe_start_auto_end_timer after ShowCardResult and SuggestResult with no pending_show_by. Add POST /ack_card_shown endpoint that starts the timer after the player dismisses the banner.

Frontend: call /ack_card_shown when dismissing the card-shown overlay instead of just clearing state.

https://claude.ai/code/session_019vkidZ19FHSvxN7nrZ5LJv