### PR TITLE
Add tunable inference_level to agents and ELO tournament script

### DIFF
--- a/backend/agent_runner.py
+++ b/backend/agent_runner.py
@@ -194,6 +194,7 @@ class AgentRunner:
 
         for pid, info in config.items():
             ptype = info["type"]
+            inf_level = info.get("inference_level", "standard")
             if ptype == "llm_agent":
                 agent: BaseAgent = LLMAgent(
                     player_id=pid,
@@ -201,6 +202,7 @@ class AgentRunner:
                     cards=info["cards"],
                     redis_client=self.redis,
                     game_id=game_id,
+                    inference_level=inf_level,
                 )
             elif ptype == "wanderer":
                 agent = WandererAgent(
@@ -209,6 +211,7 @@ class AgentRunner:
                     cards=info["cards"],
                     redis_client=self.redis,
                     game_id=game_id,
+                    inference_level=inf_level,
                 )
             else:
                 agent = RandomAgent(
@@ -217,6 +220,7 @@ class AgentRunner:
                     cards=info["cards"],
                     redis_client=self.redis,
                     game_id=game_id,
+                    inference_level=inf_level,
                 )
 
             if ptype == "llm_agent":

--- a/backend/app/games/clue/__init__.py
+++ b/backend/app/games/clue/__init__.py
@@ -15,6 +15,11 @@ from .agents import (
     RandomAgent,
     WandererAgent,
     generate_character_chat,
+    INFERENCE_NONE,
+    INFERENCE_BASIC,
+    INFERENCE_STANDARD,
+    INFERENCE_ADVANCED,
+    INFERENCE_LEVELS,
 )
 
 __all__ = [
@@ -30,4 +35,9 @@ __all__ = [
     "RandomAgent",
     "WandererAgent",
     "generate_character_chat",
+    "INFERENCE_NONE",
+    "INFERENCE_BASIC",
+    "INFERENCE_STANDARD",
+    "INFERENCE_ADVANCED",
+    "INFERENCE_LEVELS",
 ]

--- a/backend/app/games/clue/agents.py
+++ b/backend/app/games/clue/agents.py
@@ -983,16 +983,22 @@ class BaseAgent(ABC):
     def _run_unrefuted_inference(self):
         """Use unrefuted suggestions to narrow the solution (advanced inference).
 
-        An unrefuted suggestion means no active player held any of those 3
-        cards.  Combined with directly observed cards (``seen_cards``), this
-        can pin down solution components.
+        An unrefuted suggestion means no other active player held any of those
+        3 cards.  This is powerful combined with what we know:
 
-        To avoid compounding errors from prior inferences, we only treat
-        cards in ``seen_cards`` (directly observed — own hand or shown to us)
-        as confirmed when checking unrefuted triples.  If 2 of the 3 cards
-        are directly confirmed held, the remaining card is the solution for
-        its category, and all OTHER cards in that category must be held by
-        someone.
+        1. **Own-hand check**: If we hold a card in the triple, we KNOW it's
+           not the solution.  That's safe to count as "confirmed held."
+        2. **Consistency check**: If we previously saw/inferred another player
+           holds card X, but our suggestion including X was unrefuted (they
+           didn't show it), that's a contradiction — likely that player was
+           eliminated.  We only trust cards in our own hand as "confirmed"
+           within the unrefuted triple.
+        3. **Cross-unrefuted**: When multiple unrefuted suggestions share a
+           category and we can eliminate candidates, narrow further.
+
+        If 2 of the 3 cards are confirmed held (by us), the remaining card
+        is the solution for its category.  We then mark all OTHER cards in
+        that category as "inferred" (held by someone).
         """
         changed = True
         while changed:
@@ -1002,11 +1008,33 @@ class BaseAgent(ABC):
                 weapon = entry["weapon"]
                 room = entry["room"]
 
-                # Only use directly observed cards (seen_cards) to avoid
-                # compounding inference errors from earlier deductions.
+                # For unrefuted suggestions, only our OWN hand is 100%
+                # trustworthy.  Cards "known" via inference might be wrong
+                # if the holder was eliminated (they don't show during
+                # suggestion checks).  However, cards in seen_cards that
+                # are also in own_cards are safe.  Cards shown to us by
+                # others are ALSO safe if the showing player is still active,
+                # but we can't easily check that.  Use own_cards as the
+                # conservative anchor, plus any card already in
+                # inferred_cards (from PREVIOUS unrefuted deductions or
+                # cascade inference that didn't involve this suggestion).
+                confirmed_in_triple = []
                 unknown_in_triple = []
                 for card in (suspect, weapon, room):
-                    if card not in self.seen_cards:
+                    if card in self.own_cards:
+                        confirmed_in_triple.append(card)
+                    elif card in self.known_cards:
+                        # Known but not own hand — trust it if it was
+                        # directly shown to us (in seen_cards, not just
+                        # inferred).  A card shown to us by player X
+                        # proves X has it regardless of elimination status.
+                        if card in self.seen_cards:
+                            confirmed_in_triple.append(card)
+                        else:
+                            # Inferred only — less trustworthy within
+                            # an unrefuted context, but still useful
+                            confirmed_in_triple.append(card)
+                    else:
                         unknown_in_triple.append(card)
 
                 if len(unknown_in_triple) == 1:
@@ -1034,9 +1062,83 @@ class BaseAgent(ABC):
                                 eliminated=other,
                             )
                             changed = True
+
+            # Cross-unrefuted: if multiple unrefuted suggestions exist,
+            # check if negative knowledge eliminates candidates.  E.g., if
+            # two unrefuted suggestions name different suspects but the same
+            # weapon/room (both unknown), we can't narrow further.  But if
+            # ALL unrefuted suggestions name the same unknown suspect, that
+            # suspect is very likely the solution.
+            if not changed and len(self.unrefuted_suggestions) >= 2:
+                changed = self._cross_unrefuted_inference()
+
             # After processing unrefuted suggestions, also run standard cascade
             if changed:
                 self._run_inference()
+
+    def _cross_unrefuted_inference(self) -> bool:
+        """Cross-reference multiple unrefuted suggestions for deductions.
+
+        If all unrefuted suggestions agree on the same unknown card for a
+        category, and we've eliminated all other candidates in that category
+        through regular inference, we can narrow the solution.
+
+        Also: if we know N-1 cards in a category are held by players, the
+        remaining one is the solution.  Unrefuted suggestions can confirm
+        this when the remaining candidate appears in an unrefuted triple.
+        """
+        changed = False
+
+        # Collect unknown cards from unrefuted suggestions per category
+        unknown_suspects_in_unrefuted: set[str] = set()
+        unknown_weapons_in_unrefuted: set[str] = set()
+        unknown_rooms_in_unrefuted: set[str] = set()
+
+        for entry in self.unrefuted_suggestions:
+            s, w, r = entry["suspect"], entry["weapon"], entry["room"]
+            if s not in self.known_cards:
+                unknown_suspects_in_unrefuted.add(s)
+            if w not in self.known_cards:
+                unknown_weapons_in_unrefuted.add(w)
+            if r not in self.known_cards:
+                unknown_rooms_in_unrefuted.add(r)
+
+        # For each category: if all unrefuted suggestions point to the same
+        # unknown card AND that's the only unknown left, the solution is found.
+        unknown_suspects, unknown_weapons, unknown_rooms = self._get_unknowns()
+
+        for category_unknowns, unrefuted_unknowns, all_cards in [
+            (unknown_suspects, unknown_suspects_in_unrefuted, SUSPECTS),
+            (unknown_weapons, unknown_weapons_in_unrefuted, WEAPONS),
+            (unknown_rooms, unknown_rooms_in_unrefuted, ROOMS),
+        ]:
+            # If there's exactly one unknown in a category AND it appears
+            # in at least one unrefuted suggestion, we're confident
+            if (
+                len(category_unknowns) == 2
+                and len(unrefuted_unknowns) == 1
+            ):
+                solution_card = next(iter(unrefuted_unknowns))
+                other_unknown = [c for c in category_unknowns if c != solution_card]
+                if other_unknown:
+                    for other in other_unknown:
+                        if other not in self.known_cards:
+                            self.inferred_cards.add(other)
+                            reason = (
+                                f"Cross-referencing unrefuted suggestions: "
+                                f"'{solution_card}' is the only unrefuted "
+                                f"candidate — '{other}' must be held by someone."
+                            )
+                            self.card_inference_log.setdefault(other, []).append(reason)
+                            self._pending_inferences.append(f"CROSS-UNREFUTED: {reason}")
+                            self.agent_trace(
+                                "cross_unrefuted_inference",
+                                solution_card=solution_card,
+                                eliminated=other,
+                            )
+                            changed = True
+
+        return changed
 
     # ------------------------------------------------------------------
     # Helpers

--- a/backend/app/games/clue/agents.py
+++ b/backend/app/games/clue/agents.py
@@ -1690,9 +1690,31 @@ class WandererAgent(BaseAgent):
     ``observe_shown_card``.  If through passive observation and inference
     the wanderer deduces the full solution (exactly 1 unknown in each
     category), it will make an accusation.
+
+    Defaults to ``inference_level="basic"`` since wanderers never suggest
+    but need to track cards shown to them (the initial seed card).
     """
 
     agent_type = "wanderer"
+
+    def __init__(
+        self,
+        player_id: str,
+        character: str,
+        cards: list[str],
+        redis_client=None,
+        game_id: str = "",
+        *,
+        inference_level: str = INFERENCE_BASIC,
+    ):
+        super().__init__(
+            player_id=player_id,
+            character=character,
+            cards=cards,
+            redis_client=redis_client,
+            game_id=game_id,
+            inference_level=inference_level,
+        )
 
     def generate_chat(
         self, action_type: str, context: dict | None = None

--- a/backend/app/games/clue/agents.py
+++ b/backend/app/games/clue/agents.py
@@ -756,6 +756,13 @@ class BaseAgent(ABC):
 
     def observe_suggestion_no_show(self, suspect: str, weapon: str, room: str):
         """Called when a suggestion gets no card shown by anyone."""
+        if self.inference_level in (INFERENCE_NONE, INFERENCE_BASIC):
+            self.agent_trace(
+                "observe_suggestion_no_show",
+                suspect=suspect, weapon=weapon, room=room,
+                skipped=self.inference_level,
+            )
+            return
         self.unrefuted_suggestions.append(
             {"suspect": suspect, "weapon": weapon, "room": room}
         )
@@ -1112,8 +1119,9 @@ class BaseAgent(ABC):
             (unknown_weapons, unknown_weapons_in_unrefuted, WEAPONS),
             (unknown_rooms, unknown_rooms_in_unrefuted, ROOMS),
         ]:
-            # If there's exactly one unknown in a category AND it appears
-            # in at least one unrefuted suggestion, we're confident
+            # If there are exactly two unknowns in a category and only one
+            # appears in unrefuted suggestions, the OTHER unknown can be
+            # inferred as belonging to a player (not the solution).
             if (
                 len(category_unknowns) == 2
                 and len(unrefuted_unknowns) == 1

--- a/backend/app/games/clue/agents.py
+++ b/backend/app/games/clue/agents.py
@@ -45,6 +45,18 @@ _GLOBAL_AGENT_TRACE = os.getenv("AGENT_TRACE", "").strip().lower() in (
     "yes",
 )
 
+# ---------------------------------------------------------------------------
+# Inference levels — controls how much deductive reasoning agents perform.
+# Higher levels strictly include all logic from lower levels.
+# ---------------------------------------------------------------------------
+
+INFERENCE_NONE = "none"  # Only tracks own cards
+INFERENCE_BASIC = "basic"  # Tracks cards directly shown to agent
+INFERENCE_STANDARD = "standard"  # + negative knowledge + cascade inference
+INFERENCE_ADVANCED = "advanced"  # + uses unrefuted suggestions to narrow solution
+
+INFERENCE_LEVELS = [INFERENCE_NONE, INFERENCE_BASIC, INFERENCE_STANDARD, INFERENCE_ADVANCED]
+
 
 def _compute_room_distances(
     current_room: str | None, player_position: list | None
@@ -450,7 +462,15 @@ class BaseAgent(ABC):
         cards: list[str],
         redis_client=None,
         game_id: str = "",
+        *,
+        inference_level: str = INFERENCE_STANDARD,
     ):
+        if inference_level not in INFERENCE_LEVELS:
+            raise ValueError(
+                f"Invalid inference_level '{inference_level}'. "
+                f"Must be one of: {INFERENCE_LEVELS}"
+            )
+        self.inference_level: str = inference_level
         self.own_cards: set[str] = set(cards)
         self.seen_cards: set[str] = set(cards)  # own hand + directly shown
         self.inferred_cards: set[str] = set()  # deduced via elimination
@@ -478,7 +498,7 @@ class BaseAgent(ABC):
         self._game_id = game_id
         self._trace_enabled: bool | None = None  # None = check game state / env
 
-        self.agent_trace("agent_created", cards=sorted(cards))
+        self.agent_trace("agent_created", cards=sorted(cards), inference_level=inference_level)
 
     @property
     def known_cards(self) -> set[str]:
@@ -495,6 +515,7 @@ class BaseAgent(ABC):
     def get_knowledge_state(self) -> dict:
         """Export all inference/knowledge state as a serializable dict."""
         return {
+            "inference_level": self.inference_level,
             "seen_cards": sorted(self.seen_cards),
             "inferred_cards": sorted(self.inferred_cards),
             "shown_to": {k: sorted(v) for k, v in self.shown_to.items()},
@@ -711,6 +732,9 @@ class BaseAgent(ABC):
 
     def observe_shown_card(self, card: str, shown_by: str | None = None):
         """Called when another player shows us a card."""
+        if self.inference_level == INFERENCE_NONE:
+            self.agent_trace("observe_shown_card", card=card, skipped="inference_none")
+            return
         is_new = card not in self.known_cards
         self.seen_cards.add(card)
         # If it was previously only inferred, promote to seen
@@ -724,8 +748,10 @@ class BaseAgent(ABC):
             is_new=is_new,
             total_seen=len(self.seen_cards),
         )
-        if is_new:
+        if is_new and self.inference_level in (INFERENCE_STANDARD, INFERENCE_ADVANCED):
             self._run_inference()
+        if is_new and self.inference_level == INFERENCE_ADVANCED:
+            self._run_unrefuted_inference()
         self._enqueue_save_knowledge()
 
     def observe_suggestion_no_show(self, suspect: str, weapon: str, room: str):
@@ -744,6 +770,8 @@ class BaseAgent(ABC):
             room=room,
             total_unrefuted=len(self.unrefuted_suggestions),
         )
+        if self.inference_level == INFERENCE_ADVANCED:
+            self._run_unrefuted_inference()
         self._enqueue_save_knowledge()
 
     def observe_card_shown_to_other(
@@ -756,7 +784,15 @@ class BaseAgent(ABC):
         A card is impossible for the shower if: it's in our hand (unique),
         it's known to be held by a different player, or the shower is known
         not to have it.
+
+        Requires inference_level >= standard to attempt deduction.
         """
+        if self.inference_level in (INFERENCE_NONE, INFERENCE_BASIC):
+            self.agent_trace(
+                "observe_card_shown_to_other",
+                skipped=self.inference_level,
+            )
+            return
         inferred = self._try_infer_shown_card(shown_by, suspect, weapon, room)
         if inferred:
             self.agent_trace(
@@ -839,7 +875,14 @@ class BaseAgent(ABC):
 
         Records the suggestion and tracks negative knowledge: players who
         were checked and couldn't show don't have any of the suggested cards.
+        Negative knowledge tracking requires inference_level >= standard.
         """
+        if self.inference_level == INFERENCE_NONE:
+            self.agent_trace(
+                "observe_suggestion", skipped="inference_none",
+            )
+            return
+
         entry = {
             "suggesting_player_id": suggesting_player_id,
             "suspect": suspect,
@@ -850,10 +893,12 @@ class BaseAgent(ABC):
         }
         self.suggestion_log.append(entry)
 
-        # Players who were checked and couldn't show lack ALL three cards
-        suggested_cards = {suspect, weapon, room}
-        for pid in players_without_match:
-            self.player_not_has_cards.setdefault(pid, set()).update(suggested_cards)
+        # Negative knowledge requires standard+ inference
+        if self.inference_level in (INFERENCE_STANDARD, INFERENCE_ADVANCED):
+            # Players who were checked and couldn't show lack ALL three cards
+            suggested_cards = {suspect, weapon, room}
+            for pid in players_without_match:
+                self.player_not_has_cards.setdefault(pid, set()).update(suggested_cards)
 
         if players_without_match:
             names = ", ".join(self._name(pid) for pid in players_without_match)
@@ -935,6 +980,64 @@ class BaseAgent(ABC):
                     self.inferred_cards.add(inferred)
                     changed = True
 
+    def _run_unrefuted_inference(self):
+        """Use unrefuted suggestions to narrow the solution (advanced inference).
+
+        An unrefuted suggestion means no active player held any of those 3
+        cards.  Combined with directly observed cards (``seen_cards``), this
+        can pin down solution components.
+
+        To avoid compounding errors from prior inferences, we only treat
+        cards in ``seen_cards`` (directly observed — own hand or shown to us)
+        as confirmed when checking unrefuted triples.  If 2 of the 3 cards
+        are directly confirmed held, the remaining card is the solution for
+        its category, and all OTHER cards in that category must be held by
+        someone.
+        """
+        changed = True
+        while changed:
+            changed = False
+            for entry in self.unrefuted_suggestions:
+                suspect = entry["suspect"]
+                weapon = entry["weapon"]
+                room = entry["room"]
+
+                # Only use directly observed cards (seen_cards) to avoid
+                # compounding inference errors from earlier deductions.
+                unknown_in_triple = []
+                for card in (suspect, weapon, room):
+                    if card not in self.seen_cards:
+                        unknown_in_triple.append(card)
+
+                if len(unknown_in_triple) == 1:
+                    card = unknown_in_triple[0]
+                    # card is the solution for its category — mark all
+                    # OTHER cards in that category as "inferred" (held by
+                    # someone), which narrows _get_unknowns().
+                    category = (
+                        SUSPECTS if card in SUSPECTS
+                        else WEAPONS if card in WEAPONS
+                        else ROOMS
+                    )
+                    for other in category:
+                        if other != card and other not in self.known_cards:
+                            self.inferred_cards.add(other)
+                            reason = (
+                                f"Unrefuted suggestion {suspect}/{weapon}/{room} "
+                                f"pins '{card}' as solution — so '{other}' must be held by someone."
+                            )
+                            self.card_inference_log.setdefault(other, []).append(reason)
+                            self._pending_inferences.append(f"UNREFUTED DEDUCTION: {reason}")
+                            self.agent_trace(
+                                "unrefuted_inference",
+                                solution_card=card,
+                                eliminated=other,
+                            )
+                            changed = True
+            # After processing unrefuted suggestions, also run standard cascade
+            if changed:
+                self._run_inference()
+
     # ------------------------------------------------------------------
     # Helpers
     # ------------------------------------------------------------------
@@ -1002,6 +1105,7 @@ class BaseAgent(ABC):
         info: dict = {
             "player_id": self.player_id,
             "agent_type": self.agent_type,
+            "inference_level": self.inference_level,
             "character": self.character,
             "status": status,
             "action_description": action_description,
@@ -1086,6 +1190,7 @@ class RandomAgent(BaseAgent):
         redis_client=None,
         game_id: str = "",
         *,
+        inference_level: str = INFERENCE_STANDARD,
         secret_passage_chance: float | None = None,
         explore_chance: float | None = None,
         chat_frequency: float | None = None,
@@ -1096,6 +1201,7 @@ class RandomAgent(BaseAgent):
             cards=cards,
             redis_client=redis_client,
             game_id=game_id,
+            inference_level=inference_level,
         )
         self.secret_passage_chance = (
             secret_passage_chance
@@ -1172,15 +1278,16 @@ class RandomAgent(BaseAgent):
         # Phase 1: suggest first if already in a room (e.g. moved by suggestion)
         room = current_room.get(player_id)
         if room and "suggest" in available:
-            suspect = self._pick_unknown_or_random(unknown_suspects, SUSPECTS)
-            weapon = self._pick_unknown_or_random(unknown_weapons, WEAPONS)
+            suspect, weapon, reason = self._pick_suggestion(
+                unknown_suspects, unknown_weapons, room
+            )
             self.rooms_suggested_in.add(room)
             self.agent_trace(
                 "suggest",
                 suspect=suspect,
                 weapon=weapon,
                 room=room,
-                reason="prioritized",
+                reason=reason,
             )
             return SuggestAction(suspect=suspect, weapon=weapon, room=room)
 
@@ -1418,6 +1525,49 @@ class RandomAgent(BaseAgent):
 
         return random.choices(rooms_list, weights=weights, k=1)[0]
 
+    def _pick_suggestion(
+        self,
+        unknown_suspects: list[str],
+        unknown_weapons: list[str],
+        room: str,
+    ) -> tuple[str, str, str]:
+        """Pick suspect and weapon for a suggestion, returning (suspect, weapon, reason).
+
+        At advanced inference level, prioritize items from unrefuted
+        suggestions to verify suspected solution components.
+        """
+        if self.inference_level == INFERENCE_ADVANCED and self.unrefuted_suggestions:
+            # Find unrefuted suggestions matching our current room
+            for entry in self.unrefuted_suggestions:
+                if entry["room"] == room:
+                    s = entry["suspect"]
+                    w = entry["weapon"]
+                    if s in unknown_suspects and w in unknown_weapons:
+                        return s, w, "verify_unrefuted"
+
+            # Even if not in the same room, use unrefuted suspects/weapons
+            unrefuted_suspects = [
+                e["suspect"] for e in self.unrefuted_suggestions
+                if e["suspect"] in unknown_suspects
+            ]
+            unrefuted_weapons = [
+                e["weapon"] for e in self.unrefuted_suggestions
+                if e["weapon"] in unknown_weapons
+            ]
+            suspect = (
+                random.choice(unrefuted_suspects) if unrefuted_suspects
+                else self._pick_unknown_or_random(unknown_suspects, SUSPECTS)
+            )
+            weapon = (
+                random.choice(unrefuted_weapons) if unrefuted_weapons
+                else self._pick_unknown_or_random(unknown_weapons, WEAPONS)
+            )
+            return suspect, weapon, "unrefuted_guided"
+
+        suspect = self._pick_unknown_or_random(unknown_suspects, SUSPECTS)
+        weapon = self._pick_unknown_or_random(unknown_weapons, WEAPONS)
+        return suspect, weapon, "random_unknown"
+
     @staticmethod
     def _pick_unknown_or_random(unknown: list[str], full_list: list[str]) -> str:
         """Pick a random unknown card, or any card if all are known."""
@@ -1616,6 +1766,8 @@ class LLMAgent(BaseAgent):
         cards: list[str],
         redis_client=None,
         game_id: str = "",
+        *,
+        inference_level: str = INFERENCE_ADVANCED,
     ):
         super().__init__(
             player_id=player_id,
@@ -1623,6 +1775,7 @@ class LLMAgent(BaseAgent):
             cards=cards,
             redis_client=redis_client,
             game_id=game_id,
+            inference_level=inference_level,
         )
         self.api_url = os.getenv(
             "LLM_API_URL", "https://api.openai.com/v1/chat/completions"
@@ -1640,6 +1793,7 @@ class LLMAgent(BaseAgent):
             cards=cards,
             redis_client=redis_client,
             game_id=game_id,
+            inference_level=inference_level,
             secret_passage_chance=0.50,
             explore_chance=0.50,
             chat_frequency=0.50,

--- a/backend/app/games/clue/models.py
+++ b/backend/app/games/clue/models.py
@@ -516,6 +516,7 @@ class AgentPlayerConfig(BaseModel):
     character: str
     cards: list[str]
     wanderer_seed: WandererSeed | None = None
+    inference_level: str = "standard"
 
 
 class ChatContext(BaseModel):
@@ -539,6 +540,7 @@ class JoinRequest(BaseModel):
 
 class AddAgentRequest(BaseModel):
     agent_type: str = "agent"  # "agent" or "llm_agent"
+    inference_level: str = "standard"  # "none", "basic", "standard", "advanced"
 
 
 class ActionRequest(BaseModel):

--- a/backend/app/games/clue/models.py
+++ b/backend/app/games/clue/models.py
@@ -540,7 +540,7 @@ class JoinRequest(BaseModel):
 
 class AddAgentRequest(BaseModel):
     agent_type: str = "agent"  # "agent" or "llm_agent"
-    inference_level: str = "standard"  # "none", "basic", "standard", "advanced"
+    inference_level: Literal["none", "basic", "standard", "advanced"] = "standard"
 
 
 class ActionRequest(BaseModel):

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -1675,8 +1675,12 @@ async def join_game(game_id: str, req: JoinRequest):
 async def add_agent(game_id: str, req: AddAgentRequest | None = None):
     """Add an AI agent to a game in the waiting room."""
     agent_type = req.agent_type if req else "agent"
+    inference_level = req.inference_level if req else "standard"
     if agent_type not in _AGENT_PLAYER_TYPES:
         raise HTTPException(status_code=400, detail="Invalid agent type")
+    from app.games.clue.agents import INFERENCE_LEVELS
+    if inference_level not in INFERENCE_LEVELS:
+        raise HTTPException(status_code=400, detail=f"Invalid inference_level. Must be one of: {INFERENCE_LEVELS}")
 
     game = ClueGame(game_id, redis_client)
     state = await game.get_state()
@@ -1690,6 +1694,13 @@ async def add_agent(game_id: str, req: AddAgentRequest | None = None):
         player = await game.add_player(player_id, None, agent_type)
     except ValueError as exc:
         raise HTTPException(status_code=400, detail=str(exc))
+
+    # Store inference_level preference for this agent (read at game start)
+    await redis_client.set(
+        f"game:{game_id}:agent_inference:{player_id}",
+        inference_level,
+        ex=86400,
+    )
 
     state = await game.get_state()
     await manager.broadcast(
@@ -1734,11 +1745,18 @@ async def start_game(game_id: str):
         # so watchdog restarts reproduce the same starting knowledge).
         agents: dict[str, BaseAgent] = {}
         agent_cards: dict[str, list[str]] = {}
+        agent_inference_levels: dict[str, str] = {}
         for player in agent_players:
             pid = player.id
             ptype = player.type
             cards = await game._load_player_cards(pid)
             agent_cards[pid] = cards
+            # Read per-agent inference level (default: standard)
+            inference_raw = await redis_client.get(
+                f"game:{game_id}:agent_inference:{pid}"
+            )
+            inf_level = inference_raw if inference_raw else "standard"
+            agent_inference_levels[pid] = inf_level
             if ptype == "llm_agent":
                 agent: BaseAgent = LLMAgent(
                     player_id=pid,
@@ -1746,6 +1764,7 @@ async def start_game(game_id: str):
                     cards=cards,
                     redis_client=redis_client,
                     game_id=game_id,
+                    inference_level=inf_level,
                 )
                 await agent.load_memory()
             elif ptype == "wanderer":
@@ -1755,6 +1774,7 @@ async def start_game(game_id: str):
                     cards=cards,
                     redis_client=redis_client,
                     game_id=game_id,
+                    inference_level=inf_level,
                 )
             else:
                 agent = RandomAgent(
@@ -1763,6 +1783,7 @@ async def start_game(game_id: str):
                     cards=cards,
                     redis_client=redis_client,
                     game_id=game_id,
+                    inference_level=inf_level,
                 )
             agents[pid] = agent
             logger.info(
@@ -1799,6 +1820,7 @@ async def start_game(game_id: str):
                 character=player.character,
                 cards=agent_cards[pid],
                 wanderer_seed=wanderer_seeds.get(pid),
+                inference_level=agent_inference_levels.get(pid, "standard"),
             )
         await redis_client.set(
             f"game:{game_id}:agent_config",

--- a/scripts/tournament.py
+++ b/scripts/tournament.py
@@ -112,9 +112,24 @@ class PlayerStats:
 # ---------------------------------------------------------------------------
 
 
+@dataclass
+class AgentConfig:
+    """Configuration for a single agent in a tournament game."""
+
+    inference_level: str = INFERENCE_STANDARD
+    secret_passage_chance: float | None = None
+    explore_chance: float | None = None
+    chat_frequency: float | None = None
+    label: str = ""  # Human-readable label for tracking
+
+    @property
+    def display_label(self) -> str:
+        return self.label or self.inference_level
+
+
 async def run_single_game(
     game_id: str,
-    roster: list[str],
+    roster: list[str | AgentConfig],
     redis=None,
 ) -> dict:
     """Run one complete Clue game and return results.
@@ -123,53 +138,67 @@ async def run_single_game(
     ----------
     game_id : str
         Unique game identifier.
-    roster : list[str]
-        List of inference levels for each agent seat.
+    roster : list[str | AgentConfig]
+        List of inference levels (str) or AgentConfig objects.
     redis : optional
         FakeRedis instance (created if not provided).
 
     Returns
     -------
-    dict with keys: winner_idx, winner_level, turns, accusations,
-                    wrong_accusations, agents_info
+    dict with keys: winner, winner_level, turns, actions, accusations,
+                    wrong_accusations, finished, agent_levels
     """
     if redis is None:
         redis = fakeredis.FakeRedis(decode_responses=True)
+
+    # Normalize roster to AgentConfig objects
+    configs: list[AgentConfig] = []
+    for entry in roster:
+        if isinstance(entry, str):
+            configs.append(AgentConfig(inference_level=entry))
+        else:
+            configs.append(entry)
 
     game = ClueGame(game_id, redis)
     await game.create()
 
     # Add players — all as "agent" type
     player_ids = []
-    for i in range(len(roster)):
+    for i in range(len(configs)):
         pid = f"P{i}"
         await game.add_player(pid, f"Bot-{i}", "agent")
         player_ids.append(pid)
 
     state = await game.start()
 
-    # Create agents with specified inference levels
+    # Create agents with specified configs
     agents: dict[str, RandomAgent | WandererAgent] = {}
     agent_levels: dict[str, str] = {}
     for idx, p in enumerate(state.players):
         cards = await game._load_player_cards(p.id)
+        if idx < len(configs):
+            cfg = configs[idx]
+        else:
+            cfg = AgentConfig()  # default for wanderer fillers
+
         if p.type == "wanderer":
             agents[p.id] = WandererAgent(
                 player_id=p.id,
                 character=p.character,
                 cards=cards,
-                inference_level=roster[idx] if idx < len(roster) else INFERENCE_STANDARD,
             )
-            agent_levels[p.id] = roster[idx] if idx < len(roster) else INFERENCE_STANDARD
+            agent_levels[p.id] = "wanderer"
         else:
-            level = roster[idx] if idx < len(roster) else INFERENCE_STANDARD
             agents[p.id] = RandomAgent(
                 player_id=p.id,
                 character=p.character,
                 cards=cards,
-                inference_level=level,
+                inference_level=cfg.inference_level,
+                secret_passage_chance=cfg.secret_passage_chance,
+                explore_chance=cfg.explore_chance,
+                chat_frequency=cfg.chat_frequency,
             )
-            agent_levels[p.id] = level
+            agent_levels[p.id] = cfg.display_label
 
     # Show one random card to each wanderer
     real_agents = {
@@ -500,6 +529,140 @@ def print_report(results: dict):
 
 
 # ---------------------------------------------------------------------------
+# Style parameter analysis
+# ---------------------------------------------------------------------------
+
+
+async def run_style_tournament(
+    num_games: int = 200,
+    inference_level: str = INFERENCE_STANDARD,
+    quiet: bool = False,
+) -> dict:
+    """Test different style parameter combinations at a fixed inference level.
+
+    Creates named agent profiles with different secret_passage_chance,
+    explore_chance values and pits them against each other.
+    """
+    # Define style profiles to test
+    profiles: dict[str, AgentConfig] = {
+        "explorer": AgentConfig(
+            inference_level=inference_level,
+            secret_passage_chance=0.75,
+            explore_chance=0.75,
+            label="explorer",
+        ),
+        "cautious": AgentConfig(
+            inference_level=inference_level,
+            secret_passage_chance=0.25,
+            explore_chance=0.25,
+            label="cautious",
+        ),
+        "passage_lover": AgentConfig(
+            inference_level=inference_level,
+            secret_passage_chance=0.99,
+            explore_chance=0.50,
+            label="passage_lover",
+        ),
+        "passage_hater": AgentConfig(
+            inference_level=inference_level,
+            secret_passage_chance=0.01,
+            explore_chance=0.50,
+            label="passage_hater",
+        ),
+        "random_style": AgentConfig(
+            inference_level=inference_level,
+            # None = random from [0.25, 0.50, 0.75]
+            secret_passage_chance=None,
+            explore_chance=None,
+            label="random_style",
+        ),
+        "balanced": AgentConfig(
+            inference_level=inference_level,
+            secret_passage_chance=0.50,
+            explore_chance=0.50,
+            label="balanced",
+        ),
+    }
+
+    profile_names = list(profiles.keys())
+    stats: dict[str, PlayerStats] = {
+        name: PlayerStats(inference_level=name) for name in profile_names
+    }
+    matchup_wins: dict[tuple[str, str], dict[str, int]] = defaultdict(
+        lambda: defaultdict(int)
+    )
+
+    # Generate matchups: all 3-player combinations of profiles
+    matchups = list(itertools.combinations_with_replacement(profile_names, 3))
+    rosters = []
+    while len(rosters) < num_games:
+        batch = list(matchups)
+        random.shuffle(batch)
+        rosters.extend(batch)
+    rosters = rosters[:num_games]
+
+    start_time = time.time()
+    games_finished = 0
+    games_timeout = 0
+
+    for i, matchup in enumerate(rosters):
+        configs = [profiles[name] for name in matchup]
+        random.shuffle(configs)
+
+        result = await run_single_game(f"S{i}", configs)
+
+        if not result["finished"]:
+            games_timeout += 1
+            continue
+
+        games_finished += 1
+        winner_label = result.get("winner_level")
+
+        levels_in_game = list(result["agent_levels"].values())
+        for label in levels_in_game:
+            if label in stats:
+                stats[label].games += 1
+
+        if winner_label and winner_label in stats:
+            stats[winner_label].wins += 1
+            stats[winner_label].total_turns_to_win += result["turns"]
+
+            for pid, label in result["agent_levels"].items():
+                if pid != result["winner"] and label in stats:
+                    stats[label].losses += 1
+
+            # ELO
+            for pid, label in result["agent_levels"].items():
+                if pid != result["winner"] and label != winner_label:
+                    if label in stats and winner_label in stats:
+                        w_elo = stats[winner_label].elo
+                        l_elo = stats[label].elo
+                        new_w, new_l = update_elo(w_elo, l_elo)
+                        stats[winner_label].elo = new_w
+                        stats[label].elo = new_l
+
+            for pid, label in result["agent_levels"].items():
+                if pid != result["winner"]:
+                    key = tuple(sorted([winner_label, label]))
+                    matchup_wins[key][winner_label] += 1
+
+        if not quiet and (i + 1) % 100 == 0:
+            elapsed = time.time() - start_time
+            rate = (i + 1) / elapsed
+            print(f"  {i + 1}/{num_games} games ({rate:.1f} games/sec)")
+
+    elapsed = time.time() - start_time
+    return {
+        "stats": stats,
+        "matchup_wins": dict(matchup_wins),
+        "games_finished": games_finished,
+        "games_timeout": games_timeout,
+        "elapsed": elapsed,
+        "num_games": num_games,
+    }
+
+
+# ---------------------------------------------------------------------------
 # CLI
 # ---------------------------------------------------------------------------
 
@@ -529,10 +692,31 @@ def main():
         "--seed", "-s", type=int, default=None,
         help="Random seed for reproducibility.",
     )
+    parser.add_argument(
+        "--style-test", action="store_true",
+        help="Test style parameters (secret_passage_chance, explore_chance) "
+             "instead of inference levels.",
+    )
+    parser.add_argument(
+        "--style-level", type=str, default="standard",
+        help="Inference level to use for style tests (default: standard).",
+    )
     args = parser.parse_args()
 
     if args.seed is not None:
         random.seed(args.seed)
+
+    if args.style_test:
+        print(f"Running {args.games} style-parameter games at inference={args.style_level}...")
+        results = asyncio.run(
+            run_style_tournament(
+                num_games=args.games,
+                inference_level=args.style_level,
+                quiet=args.quiet,
+            )
+        )
+        print_report(results)
+        return
 
     roster = None
     if args.roster:

--- a/scripts/tournament.py
+++ b/scripts/tournament.py
@@ -28,12 +28,11 @@ import argparse
 import asyncio
 import itertools
 import json
-import math
 import random
 import sys
 import time
 from collections import defaultdict
-from dataclasses import dataclass, field
+from dataclasses import dataclass
 from pathlib import Path
 
 # Add backend/ to path so we can import app.*
@@ -42,10 +41,11 @@ sys.path.insert(0, str(_backend))
 
 import fakeredis.aioredis as fakeredis  # noqa: E402
 
-from app.games.clue.game import ClueGame, SUSPECTS, WEAPONS, ROOMS  # noqa: E402
+from app.games.clue.game import ClueGame  # noqa: E402
 from app.games.clue.agents import (  # noqa: E402
     RandomAgent,
     WandererAgent,
+    LLMAgent,
     INFERENCE_NONE,
     INFERENCE_BASIC,
     INFERENCE_STANDARD,
@@ -117,6 +117,7 @@ class AgentConfig:
     """Configuration for a single agent in a tournament game."""
 
     inference_level: str = INFERENCE_STANDARD
+    agent_type: str = "random"  # "random" or "llm"
     secret_passage_chance: float | None = None
     explore_chance: float | None = None
     chat_frequency: float | None = None
@@ -148,7 +149,8 @@ async def run_single_game(
     dict with keys: winner, winner_level, turns, actions, accusations,
                     wrong_accusations, finished, agent_levels
     """
-    if redis is None:
+    owns_redis = redis is None
+    if owns_redis:
         redis = fakeredis.FakeRedis(decode_responses=True)
 
     # Normalize roster to AgentConfig objects
@@ -172,7 +174,7 @@ async def run_single_game(
     state = await game.start()
 
     # Create agents with specified configs
-    agents: dict[str, RandomAgent | WandererAgent] = {}
+    agents: dict[str, RandomAgent | WandererAgent | LLMAgent] = {}
     agent_levels: dict[str, str] = {}
     for idx, p in enumerate(state.players):
         cards = await game._load_player_cards(p.id)
@@ -188,6 +190,14 @@ async def run_single_game(
                 cards=cards,
             )
             agent_levels[p.id] = "wanderer"
+        elif cfg.agent_type == "llm":
+            agents[p.id] = LLMAgent(
+                player_id=p.id,
+                character=p.character,
+                cards=cards,
+                inference_level=cfg.inference_level,
+            )
+            agent_levels[p.id] = cfg.display_label
         else:
             agents[p.id] = RandomAgent(
                 player_id=p.id,
@@ -279,7 +289,8 @@ async def run_single_game(
         state = await game.get_state()
         actions_taken += 1
 
-    await redis.aclose()
+    if owns_redis:
+        await redis.aclose()
 
     return {
         "winner": state.winner,
@@ -314,7 +325,7 @@ def generate_round_robin_rosters(
 
 async def run_tournament(
     num_games: int = 1000,
-    roster: list[str] | None = None,
+    roster: list[str] | list[AgentConfig] | None = None,
     num_players: int = 3,
     round_robin: bool = True,
     quiet: bool = False,
@@ -325,8 +336,8 @@ async def run_tournament(
     ----------
     num_games : int
         Total number of games to run.
-    roster : list[str] | None
-        Fixed roster of inference levels (e.g. ["advanced", "none", "standard"]).
+    roster : list[str] | list[AgentConfig] | None
+        Fixed roster of inference levels or AgentConfig objects.
         If None, uses round-robin across all matchups.
     num_players : int
         Number of players per game (only used for round-robin).
@@ -335,9 +346,20 @@ async def run_tournament(
     quiet : bool
         Suppress per-game output.
     """
+    # Collect all unique labels for stats tracking
+    all_labels: set[str] = set()
+    if roster:
+        for entry in roster:
+            if isinstance(entry, AgentConfig):
+                all_labels.add(entry.display_label)
+            else:
+                all_labels.add(entry)
+    if not all_labels:
+        all_labels = set(INFERENCE_LEVELS)
+
     stats: dict[str, PlayerStats] = {}
-    for level in INFERENCE_LEVELS:
-        stats[level] = PlayerStats(inference_level=level)
+    for label in all_labels | set(INFERENCE_LEVELS):
+        stats[label] = PlayerStats(inference_level=label)
 
     # Matchup-specific tracking: (level_a, level_b) -> {wins_a, wins_b}
     matchup_wins: dict[tuple[str, str], dict[str, int]] = defaultdict(
@@ -384,9 +406,11 @@ async def run_tournament(
         games_finished += 1
         winner_level = result["winner_level"]
 
-        # Update per-level stats
+        # Update per-level stats (lazily create for wanderers / custom labels)
         levels_in_game = list(result["agent_levels"].values())
         for level in levels_in_game:
+            if level not in stats:
+                stats[level] = PlayerStats(inference_level=level)
             stats[level].games += 1
 
         if winner_level:
@@ -693,6 +717,15 @@ def main():
         help="Random seed for reproducibility.",
     )
     parser.add_argument(
+        "--llm", type=int, default=0, metavar="N",
+        help="Include N LLM agents in each game. They replace the first N "
+             "roster slots. Requires LLM_API_KEY env var.",
+    )
+    parser.add_argument(
+        "--llm-level", type=str, default="advanced",
+        help="Inference level for LLM agents (default: advanced).",
+    )
+    parser.add_argument(
         "--style-test", action="store_true",
         help="Test style parameters (secret_passage_chance, explore_chance) "
              "instead of inference levels.",
@@ -705,6 +738,11 @@ def main():
 
     if args.seed is not None:
         random.seed(args.seed)
+
+    if args.llm > 0:
+        import os
+        if not os.getenv("LLM_API_KEY"):
+            parser.error("--llm requires LLM_API_KEY environment variable")
 
     if args.style_test:
         print(f"Running {args.games} style-parameter games at inference={args.style_level}...")
@@ -728,8 +766,45 @@ def main():
                     f"Must be one of: {INFERENCE_LEVELS}"
                 )
 
+    # Build AgentConfig roster with LLM agents if requested
+    config_roster: list[AgentConfig] | None = None
+    if args.llm > 0:
+        if roster:
+            # Replace first N slots with LLM agents
+            config_roster = []
+            for i, level in enumerate(roster):
+                if i < args.llm:
+                    config_roster.append(AgentConfig(
+                        inference_level=args.llm_level,
+                        agent_type="llm",
+                        label=f"llm({args.llm_level})",
+                    ))
+                else:
+                    config_roster.append(AgentConfig(
+                        inference_level=level,
+                        label=level,
+                    ))
+        else:
+            # Default: N LLM agents + fill remaining with advanced
+            config_roster = []
+            for i in range(args.players):
+                if i < args.llm:
+                    config_roster.append(AgentConfig(
+                        inference_level=args.llm_level,
+                        agent_type="llm",
+                        label=f"llm({args.llm_level})",
+                    ))
+                else:
+                    config_roster.append(AgentConfig(
+                        inference_level=INFERENCE_ADVANCED,
+                        label="advanced",
+                    ))
+
     print(f"Running {args.games} tournament games...")
-    if roster:
+    if config_roster:
+        labels = [c.display_label for c in config_roster]
+        print(f"  Fixed roster: {labels}")
+    elif roster:
         print(f"  Fixed roster: {roster}")
     else:
         print(f"  Round-robin mode, {args.players} players per game")
@@ -737,7 +812,7 @@ def main():
     results = asyncio.run(
         run_tournament(
             num_games=args.games,
-            roster=roster,
+            roster=config_roster or roster,
             num_players=args.players,
             quiet=args.quiet,
         )

--- a/scripts/tournament.py
+++ b/scripts/tournament.py
@@ -1,0 +1,566 @@
+#!/usr/bin/env python3
+"""ELO-style tournament runner for Clue agents.
+
+Runs N games with configurable agent compositions to measure relative
+strength of different inference levels.  Outputs ELO ratings, win rates,
+and per-matchup statistics.
+
+Usage:
+    # Run from the backend directory (needs app/ on the path):
+    cd backend && python ../scripts/tournament.py
+
+    # 500 games, 4 players each, custom composition:
+    python ../scripts/tournament.py --games 500 --players 4
+
+    # Specific matchup: 2 advanced vs 2 none
+    python ../scripts/tournament.py --roster advanced,advanced,none,none
+
+    # Full round-robin across all inference levels (default)
+    python ../scripts/tournament.py --games 1000
+
+    # Quick smoke test
+    python ../scripts/tournament.py --games 10 --quiet
+
+Requires: fakeredis (pip install fakeredis)
+"""
+
+import argparse
+import asyncio
+import itertools
+import json
+import math
+import random
+import sys
+import time
+from collections import defaultdict
+from dataclasses import dataclass, field
+from pathlib import Path
+
+# Add backend/ to path so we can import app.*
+_backend = Path(__file__).resolve().parent.parent / "backend"
+sys.path.insert(0, str(_backend))
+
+import fakeredis.aioredis as fakeredis  # noqa: E402
+
+from app.games.clue.game import ClueGame, SUSPECTS, WEAPONS, ROOMS  # noqa: E402
+from app.games.clue.agents import (  # noqa: E402
+    RandomAgent,
+    WandererAgent,
+    INFERENCE_NONE,
+    INFERENCE_BASIC,
+    INFERENCE_STANDARD,
+    INFERENCE_ADVANCED,
+    INFERENCE_LEVELS,
+)
+from app.games.clue.models import ShowCardAction  # noqa: E402
+
+MAX_TURNS = 2000
+
+
+# ---------------------------------------------------------------------------
+# ELO rating system
+# ---------------------------------------------------------------------------
+
+K_FACTOR = 32  # Standard K-factor for rating updates
+DEFAULT_ELO = 1500
+
+
+def expected_score(rating_a: float, rating_b: float) -> float:
+    """Expected score of player A vs player B."""
+    return 1.0 / (1.0 + 10.0 ** ((rating_b - rating_a) / 400.0))
+
+
+def update_elo(
+    winner_rating: float, loser_rating: float, k: float = K_FACTOR
+) -> tuple[float, float]:
+    """Return (new_winner_rating, new_loser_rating) after a win."""
+    e_win = expected_score(winner_rating, loser_rating)
+    e_lose = expected_score(loser_rating, winner_rating)
+    new_winner = winner_rating + k * (1.0 - e_win)
+    new_loser = loser_rating + k * (0.0 - e_lose)
+    return new_winner, new_loser
+
+
+# ---------------------------------------------------------------------------
+# Player tracking
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class PlayerStats:
+    """Aggregate stats for one inference-level profile."""
+
+    inference_level: str
+    elo: float = DEFAULT_ELO
+    wins: int = 0
+    losses: int = 0
+    games: int = 0
+    total_turns_to_win: int = 0
+    wrong_accusations: int = 0
+
+    @property
+    def win_rate(self) -> float:
+        return self.wins / self.games if self.games else 0.0
+
+    @property
+    def avg_turns_to_win(self) -> float:
+        return self.total_turns_to_win / self.wins if self.wins else 0.0
+
+
+# ---------------------------------------------------------------------------
+# Game runner (headless — no Redis server needed)
+# ---------------------------------------------------------------------------
+
+
+async def run_single_game(
+    game_id: str,
+    roster: list[str],
+    redis=None,
+) -> dict:
+    """Run one complete Clue game and return results.
+
+    Parameters
+    ----------
+    game_id : str
+        Unique game identifier.
+    roster : list[str]
+        List of inference levels for each agent seat.
+    redis : optional
+        FakeRedis instance (created if not provided).
+
+    Returns
+    -------
+    dict with keys: winner_idx, winner_level, turns, accusations,
+                    wrong_accusations, agents_info
+    """
+    if redis is None:
+        redis = fakeredis.FakeRedis(decode_responses=True)
+
+    game = ClueGame(game_id, redis)
+    await game.create()
+
+    # Add players — all as "agent" type
+    player_ids = []
+    for i in range(len(roster)):
+        pid = f"P{i}"
+        await game.add_player(pid, f"Bot-{i}", "agent")
+        player_ids.append(pid)
+
+    state = await game.start()
+
+    # Create agents with specified inference levels
+    agents: dict[str, RandomAgent | WandererAgent] = {}
+    agent_levels: dict[str, str] = {}
+    for idx, p in enumerate(state.players):
+        cards = await game._load_player_cards(p.id)
+        if p.type == "wanderer":
+            agents[p.id] = WandererAgent(
+                player_id=p.id,
+                character=p.character,
+                cards=cards,
+                inference_level=roster[idx] if idx < len(roster) else INFERENCE_STANDARD,
+            )
+            agent_levels[p.id] = roster[idx] if idx < len(roster) else INFERENCE_STANDARD
+        else:
+            level = roster[idx] if idx < len(roster) else INFERENCE_STANDARD
+            agents[p.id] = RandomAgent(
+                player_id=p.id,
+                character=p.character,
+                cards=cards,
+                inference_level=level,
+            )
+            agent_levels[p.id] = level
+
+    # Show one random card to each wanderer
+    real_agents = {
+        pid: a for pid, a in agents.items()
+        if a.agent_type != "wanderer" and a.own_cards
+    }
+    if real_agents:
+        for pid, a in agents.items():
+            if a.agent_type == "wanderer":
+                donor_pid, donor = random.choice(list(real_agents.items()))
+                card = random.choice(list(donor.own_cards))
+                a.observe_shown_card(card, shown_by=donor_pid)
+
+    # Share player names
+    player_names = {p.id: p.name for p in state.players}
+    for a in agents.values():
+        a.player_names = player_names
+
+    # Run game loop
+    actions_taken = 0
+    wrong_accusations = 0
+    total_accusations = 0
+
+    while state.status == "playing" and actions_taken < MAX_TURNS:
+        pending = state.pending_show_card
+        if pending:
+            pid = pending.player_id
+            agent = agents[pid]
+            suggesting_pid = pending.suggesting_player_id
+            matching = pending.matching_cards
+            card = await agent.decide_show_card(matching, suggesting_pid)
+            action = ShowCardAction(card=card)
+            result = await game.process_action(pid, action)
+
+            agents[suggesting_pid].observe_shown_card(card, shown_by=pid)
+            suspect = getattr(result, "suspect", "")
+            weapon = getattr(result, "weapon", "")
+            room = getattr(result, "room", "")
+            for aid, a in agents.items():
+                if aid not in (suggesting_pid, pid) and suspect and weapon and room:
+                    a.observe_card_shown_to_other(
+                        shown_by=pid,
+                        shown_to=suggesting_pid,
+                        suspect=suspect,
+                        weapon=weapon,
+                        room=room,
+                    )
+        else:
+            pid = state.whose_turn
+            agent = agents[pid]
+            player_state = await game.get_player_state(pid)
+            action = await agent.decide_action(state, player_state)
+            result = await game.process_action(pid, action)
+
+            if action.type == "suggest":
+                shown_by = getattr(result, "pending_show_by", None)
+                players_without = getattr(result, "players_without_match", [])
+                for aid, a in agents.items():
+                    a.observe_suggestion(
+                        suggesting_player_id=pid,
+                        suspect=action.suspect,
+                        weapon=action.weapon,
+                        room=action.room,
+                        shown_by=shown_by,
+                        players_without_match=players_without,
+                    )
+                if shown_by is None:
+                    agent.observe_suggestion_no_show(
+                        action.suspect, action.weapon, action.room,
+                    )
+
+            if action.type == "accuse":
+                total_accusations += 1
+                correct = getattr(result, "correct", False)
+                if not correct:
+                    wrong_accusations += 1
+
+        state = await game.get_state()
+        actions_taken += 1
+
+    await redis.aclose()
+
+    return {
+        "winner": state.winner,
+        "winner_level": agent_levels.get(state.winner, "?") if state.winner else None,
+        "turns": state.turn_number if hasattr(state, "turn_number") else actions_taken,
+        "actions": actions_taken,
+        "accusations": total_accusations,
+        "wrong_accusations": wrong_accusations,
+        "finished": state.status == "finished",
+        "agent_levels": agent_levels,
+    }
+
+
+# ---------------------------------------------------------------------------
+# Tournament orchestrator
+# ---------------------------------------------------------------------------
+
+
+def generate_round_robin_rosters(
+    num_players: int = 3,
+) -> list[list[str]]:
+    """Generate all unique matchup compositions for the given player count.
+
+    Returns rosters like ['none','none','standard'], ['none','basic','advanced'], etc.
+    Uses combinations with replacement so each unique composition appears once.
+    """
+    levels = [INFERENCE_NONE, INFERENCE_BASIC, INFERENCE_STANDARD, INFERENCE_ADVANCED]
+    rosters = list(itertools.combinations_with_replacement(levels, num_players))
+    # Convert tuples to lists
+    return [list(r) for r in rosters]
+
+
+async def run_tournament(
+    num_games: int = 1000,
+    roster: list[str] | None = None,
+    num_players: int = 3,
+    round_robin: bool = True,
+    quiet: bool = False,
+) -> dict:
+    """Run the full tournament and return results.
+
+    Parameters
+    ----------
+    num_games : int
+        Total number of games to run.
+    roster : list[str] | None
+        Fixed roster of inference levels (e.g. ["advanced", "none", "standard"]).
+        If None, uses round-robin across all matchups.
+    num_players : int
+        Number of players per game (only used for round-robin).
+    round_robin : bool
+        If True and no fixed roster, cycle through all matchup compositions.
+    quiet : bool
+        Suppress per-game output.
+    """
+    stats: dict[str, PlayerStats] = {}
+    for level in INFERENCE_LEVELS:
+        stats[level] = PlayerStats(inference_level=level)
+
+    # Matchup-specific tracking: (level_a, level_b) -> {wins_a, wins_b}
+    matchup_wins: dict[tuple[str, str], dict[str, int]] = defaultdict(
+        lambda: defaultdict(int)
+    )
+
+    # Build roster schedule
+    if roster:
+        rosters = [roster] * num_games
+    elif round_robin:
+        all_rosters = generate_round_robin_rosters(num_players)
+        # Repeat the roster list to fill num_games, shuffled per cycle
+        rosters = []
+        while len(rosters) < num_games:
+            batch = list(all_rosters)
+            random.shuffle(batch)
+            rosters.extend(batch)
+        rosters = rosters[:num_games]
+    else:
+        # Random composition
+        levels = list(INFERENCE_LEVELS)
+        rosters = [
+            [random.choice(levels) for _ in range(num_players)]
+            for _ in range(num_games)
+        ]
+
+    start_time = time.time()
+    games_finished = 0
+    games_timeout = 0
+
+    for i, game_roster in enumerate(rosters):
+        # Shuffle seats so position bias is controlled
+        shuffled = list(game_roster)
+        random.shuffle(shuffled)
+
+        result = await run_single_game(f"T{i}", shuffled)
+
+        if not result["finished"]:
+            games_timeout += 1
+            if not quiet:
+                print(f"  Game {i}: TIMEOUT after {result['actions']} actions")
+            continue
+
+        games_finished += 1
+        winner_level = result["winner_level"]
+
+        # Update per-level stats
+        levels_in_game = list(result["agent_levels"].values())
+        for level in levels_in_game:
+            stats[level].games += 1
+
+        if winner_level:
+            stats[winner_level].wins += 1
+            stats[winner_level].total_turns_to_win += result["turns"]
+
+            # Mark losses for non-winners
+            for pid, level in result["agent_levels"].items():
+                if pid != result["winner"]:
+                    stats[level].losses += 1
+
+            # ELO updates: winner vs each loser
+            for pid, level in result["agent_levels"].items():
+                if pid != result["winner"] and level != winner_level:
+                    w_elo = stats[winner_level].elo
+                    l_elo = stats[level].elo
+                    new_w, new_l = update_elo(w_elo, l_elo)
+                    stats[winner_level].elo = new_w
+                    stats[level].elo = new_l
+
+            # Track matchup results
+            for pid, level in result["agent_levels"].items():
+                if pid != result["winner"]:
+                    key = tuple(sorted([winner_level, level]))
+                    matchup_wins[key][winner_level] += 1
+
+        if not quiet and (i + 1) % 100 == 0:
+            elapsed = time.time() - start_time
+            rate = (i + 1) / elapsed
+            print(f"  {i + 1}/{num_games} games ({rate:.1f} games/sec)")
+
+    elapsed = time.time() - start_time
+
+    return {
+        "stats": stats,
+        "matchup_wins": dict(matchup_wins),
+        "games_finished": games_finished,
+        "games_timeout": games_timeout,
+        "elapsed": elapsed,
+        "num_games": num_games,
+    }
+
+
+# ---------------------------------------------------------------------------
+# Reporting
+# ---------------------------------------------------------------------------
+
+
+def print_report(results: dict):
+    """Print a formatted tournament report."""
+    stats = results["stats"]
+    matchup_wins = results["matchup_wins"]
+
+    print("\n" + "=" * 70)
+    print("  CLUE AGENT TOURNAMENT RESULTS")
+    print("=" * 70)
+    print(
+        f"  Games: {results['games_finished']} finished, "
+        f"{results['games_timeout']} timeouts, "
+        f"{results['elapsed']:.1f}s elapsed"
+    )
+    print()
+
+    # Sort by ELO descending
+    sorted_stats = sorted(stats.values(), key=lambda s: s.elo, reverse=True)
+
+    print(f"  {'Level':<12} {'ELO':>6} {'Wins':>6} {'Games':>6} {'Win%':>7} {'Avg Turns':>10}")
+    print("  " + "-" * 53)
+    for s in sorted_stats:
+        if s.games == 0:
+            continue
+        print(
+            f"  {s.inference_level:<12} {s.elo:>6.0f} {s.wins:>6} "
+            f"{s.games:>6} {s.win_rate:>6.1%} {s.avg_turns_to_win:>10.1f}"
+        )
+
+    # Matchup matrix
+    levels_with_games = [s.inference_level for s in sorted_stats if s.games > 0]
+    if matchup_wins and len(levels_with_games) > 1:
+        print()
+        print("  HEAD-TO-HEAD WIN RATES:")
+        print(f"  {'':>12}", end="")
+        for level in levels_with_games:
+            print(f" {level[:8]:>8}", end="")
+        print()
+        print("  " + "-" * (12 + 9 * len(levels_with_games)))
+
+        for row_level in levels_with_games:
+            print(f"  {row_level:<12}", end="")
+            for col_level in levels_with_games:
+                if row_level == col_level:
+                    print(f" {'---':>8}", end="")
+                    continue
+                key = tuple(sorted([row_level, col_level]))
+                data = matchup_wins.get(key, {})
+                row_wins = data.get(row_level, 0)
+                col_wins = data.get(col_level, 0)
+                total = row_wins + col_wins
+                if total == 0:
+                    print(f" {'N/A':>8}", end="")
+                else:
+                    rate = row_wins / total
+                    print(f" {rate:>7.1%}", end="")
+            print()
+
+    print()
+    print("  DIFFICULTY TIERS (suggested):")
+    for s in sorted_stats:
+        if s.games == 0:
+            continue
+        if s.elo >= 1550:
+            tier = "HARD"
+        elif s.elo >= 1480:
+            tier = "MEDIUM"
+        else:
+            tier = "EASY"
+        print(f"    {s.inference_level:<12} -> {tier} (ELO {s.elo:.0f})")
+
+    print()
+
+    # JSON summary for programmatic use
+    summary = {
+        "ratings": {
+            s.inference_level: {
+                "elo": round(s.elo),
+                "wins": s.wins,
+                "games": s.games,
+                "win_rate": round(s.win_rate, 3),
+                "avg_turns_to_win": round(s.avg_turns_to_win, 1),
+            }
+            for s in sorted_stats
+            if s.games > 0
+        },
+        "games_finished": results["games_finished"],
+        "elapsed_seconds": round(results["elapsed"], 1),
+    }
+    print("  JSON summary:")
+    print("  " + json.dumps(summary, indent=2).replace("\n", "\n  "))
+    print()
+
+
+# ---------------------------------------------------------------------------
+# CLI
+# ---------------------------------------------------------------------------
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="Run ELO-style tournament for Clue agents with different inference levels."
+    )
+    parser.add_argument(
+        "--games", "-n", type=int, default=1000,
+        help="Number of games to run (default: 1000)",
+    )
+    parser.add_argument(
+        "--players", "-p", type=int, default=3,
+        help="Players per game for round-robin mode (default: 3)",
+    )
+    parser.add_argument(
+        "--roster", "-r", type=str, default=None,
+        help="Comma-separated inference levels (e.g. 'advanced,standard,none'). "
+             "Overrides round-robin.",
+    )
+    parser.add_argument(
+        "--quiet", "-q", action="store_true",
+        help="Suppress per-game output.",
+    )
+    parser.add_argument(
+        "--seed", "-s", type=int, default=None,
+        help="Random seed for reproducibility.",
+    )
+    args = parser.parse_args()
+
+    if args.seed is not None:
+        random.seed(args.seed)
+
+    roster = None
+    if args.roster:
+        roster = [level.strip() for level in args.roster.split(",")]
+        for level in roster:
+            if level not in INFERENCE_LEVELS:
+                parser.error(
+                    f"Invalid inference level '{level}'. "
+                    f"Must be one of: {INFERENCE_LEVELS}"
+                )
+
+    print(f"Running {args.games} tournament games...")
+    if roster:
+        print(f"  Fixed roster: {roster}")
+    else:
+        print(f"  Round-robin mode, {args.players} players per game")
+
+    results = asyncio.run(
+        run_tournament(
+            num_games=args.games,
+            roster=roster,
+            num_players=args.players,
+            quiet=args.quiet,
+        )
+    )
+
+    print_report(results)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Introduces a 4-tier inference system (none/basic/standard/advanced) that
controls how much deductive reasoning Clue agents perform:
- none: only tracks own hand, no learning from observations
- basic: tracks cards directly shown, no cascade deduction
- standard: full cascade inference + negative knowledge (default)
- advanced: standard + unrefuted suggestion analysis

The inference_level is configurable per-agent via the /add_agent API
(inference_level field) and persisted in AgentPlayerConfig for agent
runner restarts.

Also adds scripts/tournament.py — an ELO-rated tournament runner that
plays N headless games with configurable agent compositions. Supports
round-robin matchups, fixed rosters, reproducible seeds, and outputs
ELO ratings, win rates, and head-to-head matrices.

https://claude.ai/code/session_01R2mA3j4UcY66BqqoXxJQnU