### PR TITLE
Add strategic decoy suggestions when categories narrow to one unknown

### DIFF
--- a/backend/app/games/clue/agents.py
+++ b/backend/app/games/clue/agents.py
@@ -1653,6 +1653,11 @@ class RandomAgent(BaseAgent):
     ) -> tuple[str, str, str]:
         """Pick suspect and weapon for a suggestion, returning (suspect, weapon, reason).
 
+        When a category is narrowed to exactly one unknown (the likely
+        solution), use a card from our own hand for that category instead.
+        This adds unpredictability and lets the suggestion focus on
+        narrowing other categories that still have multiple unknowns.
+
         At advanced inference level, prioritize items from unrefuted
         suggestions to verify suspected solution components.
         """
@@ -1679,22 +1684,38 @@ class RandomAgent(BaseAgent):
             suspect = (
                 random.choice(unrefuted_suspects)
                 if unrefuted_suspects
-                else self._pick_unknown_or_random(unknown_suspects, SUSPECTS)
+                else self._pick_narrowed_or_unknown(unknown_suspects, SUSPECTS)
             )
             weapon = (
                 random.choice(unrefuted_weapons)
                 if unrefuted_weapons
-                else self._pick_unknown_or_random(unknown_weapons, WEAPONS)
+                else self._pick_narrowed_or_unknown(unknown_weapons, WEAPONS)
             )
             return suspect, weapon, "unrefuted_guided"
 
-        suspect = self._pick_unknown_or_random(unknown_suspects, SUSPECTS)
-        weapon = self._pick_unknown_or_random(unknown_weapons, WEAPONS)
+        suspect = self._pick_narrowed_or_unknown(unknown_suspects, SUSPECTS)
+        weapon = self._pick_narrowed_or_unknown(unknown_weapons, WEAPONS)
         return suspect, weapon, "random_unknown"
 
-    @staticmethod
-    def _pick_unknown_or_random(unknown: list[str], full_list: list[str]) -> str:
-        """Pick a random unknown card, or any card if all are known."""
+    def _pick_narrowed_or_unknown(
+        self, unknown: list[str], full_list: list[str]
+    ) -> str:
+        """Pick a card for a suggestion category.
+
+        If the category is narrowed to exactly one unknown (likely the
+        solution), prefer a card from our own hand instead — this avoids
+        always suggesting the deduced solution card (which is predictable
+        and reveals our knowledge) and lets us gather info on other
+        categories.  If we have no hand cards in this category, fall back
+        to the single unknown.
+        """
+        if len(unknown) == 1:
+            # Category is narrowed — use a hand card as a decoy if possible
+            own_in_category = [c for c in full_list if c in self.own_cards]
+            if own_in_category:
+                return random.choice(own_in_category)
+            # No hand cards in this category; use the single unknown
+            return unknown[0]
         if unknown:
             return random.choice(unknown)
         return random.choice(full_list)

--- a/backend/tests/test_agent_game.py
+++ b/backend/tests/test_agent_game.py
@@ -272,7 +272,13 @@ async def test_agent_accuses_only_when_certain(redis):
 
 @pytest.mark.asyncio
 async def test_agent_never_suggests_own_cards(redis):
-    """The agent should prefer unknown cards in suggestions."""
+    """The agent should prefer unknown cards in suggestions.
+
+    When multiple unknowns exist in a category, the agent picks from
+    unknowns (not hand cards).  When narrowed to exactly 1 unknown, the
+    agent deliberately uses a hand card as a decoy to add randomness and
+    focus info-gathering on other categories.
+    """
     game, agents, state = await _setup_game(redis, num_agents=2)
     final_state, turns, log = await _run_game(game, agents, state)
 
@@ -280,20 +286,20 @@ async def test_agent_never_suggests_own_cards(redis):
         if action.type == "suggest":
             agent = agents[pid]
             cards = await game._load_player_cards(pid)
-            # Suspect and weapon should NOT be in the agent's hand
-            # (unless all suspects or all weapons are known)
             unknown_suspects = [s for s in SUSPECTS if s not in agent.known_cards]
             unknown_weapons = [w for w in WEAPONS if w not in agent.known_cards]
 
-            if unknown_suspects:
+            # Only assert hand-card avoidance when multiple unknowns exist;
+            # with exactly 1 unknown the agent intentionally uses hand cards.
+            if len(unknown_suspects) > 1:
                 assert action.suspect not in cards, (
                     f"Agent {pid} suggested a suspect from its own hand "
-                    f"when unknowns existed: {action.suspect}"
+                    f"when multiple unknowns existed: {action.suspect}"
                 )
-            if unknown_weapons:
+            if len(unknown_weapons) > 1:
                 assert action.weapon not in cards, (
                     f"Agent {pid} suggested a weapon from its own hand "
-                    f"when unknowns existed: {action.weapon}"
+                    f"when multiple unknowns existed: {action.weapon}"
                 )
 
 


### PR DESCRIPTION
## Summary
Improved the Clue agent's suggestion strategy to add unpredictability and better information gathering. When a category (suspect or weapon) is narrowed down to exactly one unknown card, the agent now deliberately suggests a card from its own hand as a decoy instead of always suggesting the deduced solution card.

## Key Changes
- Renamed `_pick_unknown_or_random()` to `_pick_narrowed_or_unknown()` and converted it from a static method to an instance method to access `self.own_cards`
- Implemented new logic: when a category has exactly 1 unknown remaining (likely the solution), prefer suggesting a card from the agent's own hand if available
- Falls back to the single unknown card only if no hand cards exist in that category
- Updated test expectations in `test_agent_never_suggests_own_cards` to reflect the new behavior: assertions only apply when multiple unknowns exist in a category, not when narrowed to one

## Implementation Details
The strategy change addresses two goals:
1. **Unpredictability**: Avoids always suggesting the deduced solution card, which is predictable and reveals the agent's knowledge
2. **Better info-gathering**: Allows suggestions to focus on narrowing other categories that still have multiple unknowns, rather than confirming what's already been deduced

The implementation gracefully handles edge cases where an agent has no hand cards in a particular category by falling back to suggesting the single unknown.

https://claude.ai/code/session_01X7sqELemczAasqMN2r2Co3