### PR TITLE
Fix auto-end-turn timer not starting after dismissing card-shown banner

### DIFF
--- a/frontend/src/components/clue/GameBoard.vue
+++ b/frontend/src/components/clue/GameBoard.vue
@@ -683,6 +683,7 @@ const cardShownDismissedOnce = ref(false)
 
 function dismissCardShownOverlay() {
   cardShownDismissedOnce.value = true
+  emit('dismiss-card-shown')
 }
 
 // Game over overlay state


### PR DESCRIPTION
dismissCardShownOverlay() was missing the emit('dismiss-card-shown') call, so the parent never called /ack_card_shown and the timer never started.