### PR TITLE
Fix poker betting rules: min raise tracks previous raise size, slider uses pot

### DIFF
--- a/backend/app/games/holdem/agents.py
+++ b/backend/app/games/holdem/agents.py
@@ -367,8 +367,10 @@ class HoldemAgent:
                 raise_amount = self._compute_raise(
                     pot, amount_to_call, chips, strength, state
                 )
+                last_raise = getattr(state, 'last_raise_size', state.big_blind)
+                min_raise_total = amount_to_call + max(state.big_blind, last_raise)
                 if (
-                    raise_amount < amount_to_call + state.big_blind
+                    raise_amount < min_raise_total
                     and "all_in" in available
                 ):
                     return AllInAction()
@@ -405,8 +407,10 @@ class HoldemAgent:
                 raise_amount = self._compute_raise(
                     pot, amount_to_call, chips, strength, state
                 )
+                last_raise = getattr(state, 'last_raise_size', state.big_blind)
+                min_raise_total = amount_to_call + max(state.big_blind, last_raise)
                 if (
-                    raise_amount < amount_to_call + state.big_blind
+                    raise_amount < min_raise_total
                     and "all_in" in available
                 ):
                     return AllInAction()
@@ -455,7 +459,8 @@ class HoldemAgent:
         state: HoldemGameState,
     ) -> int:
         """Compute a raise amount (total bet including call portion)."""
-        min_raise = amount_to_call + state.big_blind
+        last_raise = getattr(state, 'last_raise_size', state.big_blind)
+        min_raise = amount_to_call + max(state.big_blind, last_raise)
         # Raise between min and 2.5x pot based on strength
         fraction = 0.5 + (strength - 0.5) * 2.0
         fraction = max(0.5, min(2.5, fraction))

--- a/backend/app/games/holdem/game.py
+++ b/backend/app/games/holdem/game.py
@@ -190,6 +190,7 @@ class HoldemGame:
         state.betting_round = "preflop"
         state.last_raiser = None
         state.actions_this_round = 0
+        state.last_raise_size = state.big_blind  # initial min raise = big blind
 
         # Reset per-hand player state
         for p in state.players:
@@ -296,7 +297,10 @@ class HoldemGame:
             # Must call or raise
             if player.chips >= amount_to_call:
                 actions.append("call")
-            if player.chips > amount_to_call:
+            # Only offer raise if player can meet the minimum raise
+            min_raise_size = max(state.big_blind, state.last_raise_size)
+            min_raise_total = amount_to_call + min_raise_size
+            if player.chips >= min_raise_total:
                 actions.append("raise")
 
         # Can always go all-in if they have chips
@@ -446,6 +450,7 @@ class HoldemGame:
         state.current_bet = player.current_bet
         state.pot += amount
         state.last_raiser = player.id
+        state.last_raise_size = amount  # opening bet sets the raise size
         state.actions_this_round = 1
         if player.chips == 0:
             player.all_in = True
@@ -467,8 +472,10 @@ class HoldemGame:
         """Handle a raise. `amount` is the TOTAL bet the player wants to make."""
         amount_to_call = state.current_bet - player.current_bet
         raise_portion = amount - amount_to_call
-        if raise_portion < state.big_blind and amount < player.chips:
-            raise ValueError(f"Minimum raise is {state.big_blind}")
+        # Min raise must be at least the size of the last bet/raise
+        min_raise = max(state.big_blind, state.last_raise_size)
+        if raise_portion < min_raise and amount < player.chips:
+            raise ValueError(f"Minimum raise is {min_raise}")
         if amount % MIN_CHIP != 0 and amount < player.chips:
             raise ValueError(f"Raise must be a multiple of {MIN_CHIP}")
         if amount > player.chips:
@@ -479,6 +486,7 @@ class HoldemGame:
         state.current_bet = player.current_bet
         state.pot += amount
         state.last_raiser = player.id
+        state.last_raise_size = raise_portion  # track for next min-raise
         state.actions_this_round = 1
         if player.chips == 0:
             player.all_in = True
@@ -499,10 +507,14 @@ class HoldemGame:
     ) -> AllInResult:
         amount = player.chips
         player.chips = 0
+        old_current_bet = state.current_bet
         player.current_bet += amount
         if player.current_bet > state.current_bet:
+            raise_portion = player.current_bet - old_current_bet
             state.current_bet = player.current_bet
             state.last_raiser = player.id
+            if raise_portion > state.last_raise_size:
+                state.last_raise_size = raise_portion
             state.actions_this_round = 1
         else:
             state.actions_this_round += 1
@@ -594,6 +606,7 @@ class HoldemGame:
         state.current_bet = 0
         state.last_raiser = None
         state.actions_this_round = 0
+        state.last_raise_size = state.big_blind  # reset to big blind each round
 
         deck = await self._load_deck()
 

--- a/backend/app/games/holdem/models.py
+++ b/backend/app/games/holdem/models.py
@@ -85,6 +85,7 @@ class HoldemGameState(BaseModel):
     # Track who has acted this betting round
     last_raiser: Optional[str] = None
     actions_this_round: int = 0
+    last_raise_size: int = 0  # size of the last bet/raise (for min-raise rule)
 
     # Result of the last completed hand (persists until next action)
     last_hand_result: Optional["HoldemHandResult"] = None

--- a/backend/tests/test_holdem.py
+++ b/backend/tests/test_holdem.py
@@ -517,11 +517,11 @@ async def test_raise_must_be_chip_multiple(redis):
         available = game.get_available_actions(whose_turn, state)
 
     if "raise" in available:
-        # 63 is not a multiple of 5
+        # 83 is not a multiple of 5 (raise portion 43 meets min raise of 40)
         with pytest.raises(ValueError, match="multiple of 5"):
-            await game.process_action(whose_turn, {"type": "raise", "amount": 63})
-        # 65 is valid (multiple of 5: e.g. 25 + 4×10)
-        result = await game.process_action(whose_turn, {"type": "raise", "amount": 65})
+            await game.process_action(whose_turn, {"type": "raise", "amount": 83})
+        # 85 is valid (multiple of 5, raise portion 45 meets min raise of 40)
+        result = await game.process_action(whose_turn, {"type": "raise", "amount": 85})
         assert result.type == "raise"
 
 

--- a/frontend/src/components/holdem/PokerTable.vue
+++ b/frontend/src/components/holdem/PokerTable.vue
@@ -221,13 +221,13 @@
               <div class="slider-row">
                 <div class="preset-pills">
                   <button @click="betAmount = gameState?.big_blind ?? 20" class="pill">Min</button>
-                  <button @click="betAmount = roundToChip((myPlayer?.chips ?? 0) / 3)" class="pill">
-                    &frac13;
+                  <button @click="betAmount = Math.max(gameState?.big_blind ?? 20, roundToChip((gameState?.pot ?? 0) / 3))" class="pill">
+                    &frac13; Pot
                   </button>
-                  <button @click="betAmount = roundToChip((myPlayer?.chips ?? 0) / 2)" class="pill">
-                    &frac12;
+                  <button @click="betAmount = Math.max(gameState?.big_blind ?? 20, roundToChip((gameState?.pot ?? 0) / 2))" class="pill">
+                    &frac12; Pot
                   </button>
-                  <button @click="betAmount = myPlayer?.chips ?? 0" class="pill">Max</button>
+                  <button @click="betAmount = roundToChip(gameState?.pot ?? 0)" class="pill">Pot</button>
                 </div>
                 <div class="range-track">
                   <input type="range" :min="gameState?.big_blind ?? 20" :max="myPlayer?.chips ?? 0"
@@ -250,13 +250,13 @@
               <div class="slider-row">
                 <div class="preset-pills">
                   <button @click="raiseAmount = minRaise" class="pill">Min</button>
-                  <button @click="raiseAmount = roundToChip((myPlayer?.chips ?? 0) / 2)" class="pill">
-                    &frac12;
+                  <button @click="raiseAmount = Math.max(minRaise, roundToChip((gameState?.pot ?? 0) / 2))" class="pill">
+                    &frac12; Pot
                   </button>
-                  <button @click="raiseAmount = roundToChip(((myPlayer?.chips ?? 0) * 3) / 4)" class="pill">
-                    &frac34;
+                  <button @click="raiseAmount = Math.max(minRaise, roundToChip(((gameState?.pot ?? 0) * 3) / 4))" class="pill">
+                    &frac34; Pot
                   </button>
-                  <button @click="raiseAmount = myPlayer?.chips ?? 0" class="pill">Pot</button>
+                  <button @click="raiseAmount = Math.max(minRaise, roundToChip(gameState?.pot ?? 0))" class="pill">Pot</button>
                 </div>
                 <div class="range-track">
                   <input type="range" :min="minRaise" :max="myPlayer?.chips ?? 0" :step="MIN_CHIP"
@@ -478,7 +478,8 @@ const amountToCall = computed(() => {
 const minRaise = computed(() => {
   const call = amountToCall.value
   const bb = props.gameState?.big_blind ?? 20
-  return call + bb
+  const lastRaise = props.gameState?.last_raise_size ?? bb
+  return call + Math.max(bb, lastRaise)
 })
 
 const canFold = computed(() => props.availableActions.includes('fold'))


### PR DESCRIPTION
- Add last_raise_size to game state to track the size of the last bet/raise
- Minimum re-raise must now match the previous raise size (not just big blind)
- Only offer "raise" action when player can meet the minimum raise
- Fix frontend bet slider pills (1/3, 1/2) to use pot size instead of stack
- Fix raise slider pills (1/2, 3/4, Pot) to use pot size instead of stack
- Fix misleading "Pot" button on raise slider (was actually "Max/All-in")
- Update agent _compute_raise to respect last_raise_size
- Update tests for new minimum raise validation

https://claude.ai/code/session_01RVQ4ahyqbameH2nnpKWUQH