### PR TITLE
Add funny poker player names and LLM nano personality chat

### DIFF
--- a/backend/app/games/holdem/agents.py
+++ b/backend/app/games/holdem/agents.py
@@ -4,11 +4,15 @@ HoldemAgent uses a simple rule-based strategy:
 - Evaluates hand strength based on hole cards and community cards
 - Makes betting decisions based on hand strength relative to pot odds
 - Varies play style with configurable aggression
+- Uses LLM nano for personality-driven chat when available
 """
 
 import logging
+import os
 import random
 from itertools import combinations
+
+import httpx
 
 from .hand_eval import evaluate_hand, HAND_NAMES, ONE_PAIR, TWO_PAIR, FLUSH, STRAIGHT
 from .models import (
@@ -87,6 +91,55 @@ def get_personality(name: str | None = None) -> tuple[str, dict]:
         return name, dict(PERSONALITIES[name])
     chosen_name = random.choice(PERSONALITY_NAMES)
     return chosen_name, dict(PERSONALITIES[chosen_name])
+
+
+# ---------------------------------------------------------------------------
+# LLM personality prompts — give each archetype a distinct voice
+# ---------------------------------------------------------------------------
+
+_PERSONALITY_SYSTEM_PROMPTS: dict[str, str] = {
+    "Rock": (
+        "You are a tight, patient poker player named {name}. You barely talk, "
+        "and when you do it's dry, understated wit. You've been playing poker "
+        "since before these kids were born. Think grizzled old-timer energy. "
+        "You fold a lot and you're proud of it."
+    ),
+    "Maniac": (
+        "You are a chaotic, hyperactive poker player named {name}. You're loud, "
+        "unpredictable, and you LOVE going all in. You trash talk constantly, "
+        "use too many exclamation marks, and reference action movies. You think "
+        "every hand is THE hand. You're having the time of your life."
+    ),
+    "Shark": (
+        "You are a cold, calculating poker pro named {name}. You speak in "
+        "clipped, confident phrases. You occasionally drop poker math into "
+        "conversation to intimidate people. You respect good play and mock "
+        "bad play with subtle sarcasm. Think sunglasses-at-the-table energy."
+    ),
+    "Fish": (
+        "You are a lovable beginner poker player named {name}. You don't fully "
+        "understand the rules and you're having a blast anyway. You ask dumb "
+        "questions, misuse poker terminology hilariously, and get excited about "
+        "bad hands. You think a pair of 3s is amazing."
+    ),
+    "Nit": (
+        "You are an extremely cautious poker player named {name}. You are "
+        "paranoid that everyone has a better hand. You fold almost everything "
+        "and complain about your cards constantly. You keep track of every chip "
+        "you lose and mention it. You are not having fun but can't stop playing."
+    ),
+    "LAG": (
+        "You are a loose-aggressive poker player named {name}. You're smooth, "
+        "cocky, and love applying pressure. You narrate your own plays like a "
+        "sports commentator. You give opponents nicknames. You bluff with "
+        "theatrical confidence and act shocked when caught."
+    ),
+}
+
+_DEFAULT_PERSONALITY_PROMPT = (
+    "You are a poker player named {name}. You have a fun, "
+    "distinct personality at the table. Be witty and entertaining."
+)
 
 
 # ---------------------------------------------------------------------------
@@ -249,6 +302,13 @@ class HoldemAgent:
         self.bluff_frequency = max(0.0, min(1.0, bluff_frequency))
         self.slowplay_frequency = max(0.0, min(1.0, slowplay_frequency))
         self.chat_frequency = max(0.0, min(1.0, chat_frequency))
+
+        # LLM nano config for personality-driven chat
+        self.llm_api_url = os.getenv(
+            "LLM_API_URL", "https://api.openai.com/v1/chat/completions"
+        )
+        self.llm_api_key = os.getenv("LLM_API_KEY", "")
+        self.llm_nano_model = os.getenv("LLM_NANO_MODEL", "gpt-5-nano")
         logger.info(
             "[holdem_agent] Created agent %s (%s) personality=%s aggression=%.2f "
             "tightness=%.2f bluff=%.2f slowplay=%.2f chat=%.2f",
@@ -468,11 +528,18 @@ class HoldemAgent:
             amount = max(min_raise, amount)
         return amount
 
-    def generate_chat(self, action_type: str, **kwargs) -> str | None:
-        """Occasionally generate a personality-flavored chat message."""
+    async def generate_chat(self, action_type: str, **kwargs) -> str | None:
+        """Generate a personality-flavored chat message, using LLM nano when available."""
         if random.random() > self.chat_frequency:
             return None
 
+        # Try LLM nano first for dynamic, personality-driven chat
+        if self.llm_api_key:
+            llm_msg = await self._llm_chat(action_type, **kwargs)
+            if llm_msg:
+                return llm_msg
+
+        # Fall back to template chat
         options = _PERSONALITY_CHAT.get(self.personality, _DEFAULT_CHAT).get(
             action_type
         )
@@ -481,6 +548,53 @@ class HoldemAgent:
             options = _DEFAULT_CHAT.get(action_type, ["Hmm..."])
 
         return random.choice(options)
+
+    async def _llm_chat(self, action_type: str, **kwargs) -> str | None:
+        """Call LLM nano for a short, in-character chat line."""
+        system_template = _PERSONALITY_SYSTEM_PROMPTS.get(
+            self.personality, _DEFAULT_PERSONALITY_PROMPT
+        )
+        system = system_template.format(name=self.name)
+
+        context_parts = [f"You just decided to: {action_type}."]
+        if kwargs.get("community_cards"):
+            context_parts.append(f"Community cards: {kwargs['community_cards']}")
+        if kwargs.get("pot"):
+            context_parts.append(f"Pot size: {kwargs['pot']}")
+
+        user = (
+            " ".join(context_parts)
+            + "\n\nSay ONE short sentence (under 15 words) in character. "
+            "Be funny, witty, or dramatic. No quotes. No emojis. Just the line."
+        )
+
+        headers = {
+            "Authorization": f"Bearer {self.llm_api_key}",
+            "Content-Type": "application/json",
+        }
+        payload = {
+            "model": self.llm_nano_model,
+            "messages": [
+                {"role": "system", "content": system},
+                {"role": "user", "content": user},
+            ],
+            "max_tokens": 50,
+        }
+
+        try:
+            async with httpx.AsyncClient(timeout=5.0) as client:
+                resp = await client.post(
+                    self.llm_api_url, json=payload, headers=headers
+                )
+                resp.raise_for_status()
+                data = resp.json()
+                content = data["choices"][0]["message"]["content"].strip().strip('"')
+                if content:
+                    return content
+        except Exception as exc:
+            logger.debug("[holdem_agent:%s] LLM chat failed: %s", self.player_id, exc)
+
+        return None
 
 
 # ---------------------------------------------------------------------------

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -199,16 +199,31 @@ _holdem_agents: dict[str, dict[str, HoldemAgent]] = {}
 _holdem_agent_tasks: dict[str, asyncio.Task] = {}
 
 _HOLDEM_AGENT_NAMES = [
-    "Ace",
-    "Bluff",
-    "Chip",
-    "Dealer",
-    "Edge",
-    "Flop",
-    "Gambit",
-    "High Card",
-    "Jackpot",
-    "Kicker",
+    "Ace Ventura",
+    "Bluff Daddy",
+    "Chip Hazard",
+    "The Dealer of Doom",
+    "Lady Luck",
+    "Floppy McFlopface",
+    "Gambit the Unreadable",
+    "High Card Houdini",
+    "Jackpot Jenkins",
+    "Kicker? I Hardly Know Her",
+    "All-In Alan",
+    "Fold McFoldington",
+    "River Rat Rick",
+    "Pocket Rocket Pete",
+    "The Velvet Hammer",
+    "Sir Bets-a-Lot",
+    "Check Norris",
+    "Phil Hellmouth",
+    "Tilt McGee",
+    "Raise the Roof Reggie",
+    "No Limit Nancy",
+    "Fishy McFishface",
+    "The Gutshot Kid",
+    "Bad Beat Barbara",
+    "Stone Cold Bluffer",
 ]
 
 
@@ -2563,7 +2578,11 @@ async def _run_holdem_agent_loop(game_id: str):
 
                     # Chat (non-critical — don't let it kill the loop)
                     try:
-                        chat_msg = agent.generate_chat(action.type)
+                        chat_msg = await agent.generate_chat(
+                            action.type,
+                            community_cards=[str(c) for c in state.community_cards] if state.community_cards else None,
+                            pot=state.pot,
+                        )
                         if chat_msg:
                             await _holdem_broadcast_chat(
                                 game_id, f"{agent.name}: {chat_msg}", whose_turn

--- a/backend/tests/test_holdem_agent.py
+++ b/backend/tests/test_holdem_agent.py
@@ -151,25 +151,28 @@ class TestHoldemAgentDecisions:
         assert agent.slowplay_frequency == 1.0
         assert agent.chat_frequency == 0.0
 
-    def test_generate_chat_sometimes_returns_none(self):
+    @pytest.mark.asyncio
+    async def test_generate_chat_sometimes_returns_none(self):
         """Chat generation is probabilistic — just verify it returns string or None."""
         agent = HoldemAgent("P1", "TestBot")
         results = set()
         for _ in range(100):
-            result = agent.generate_chat("fold")
+            result = await agent.generate_chat("fold")
             results.add(type(result))
         # Should get both None and str across many tries
         assert type(None) in results or str in results
 
-    def test_chat_frequency_zero_never_chats(self):
+    @pytest.mark.asyncio
+    async def test_chat_frequency_zero_never_chats(self):
         agent = HoldemAgent("P1", "TestBot", chat_frequency=0.0)
         for _ in range(50):
-            assert agent.generate_chat("fold") is None
+            assert await agent.generate_chat("fold") is None
 
-    def test_chat_frequency_one_always_chats(self):
+    @pytest.mark.asyncio
+    async def test_chat_frequency_one_always_chats(self):
         agent = HoldemAgent("P1", "TestBot", chat_frequency=1.0)
         for _ in range(50):
-            assert agent.generate_chat("fold") is not None
+            assert await agent.generate_chat("fold") is not None
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
- Replace generic agent names (Ace, Bluff, Chip...) with 25 funny names
  like "Check Norris", "Floppy McFlopface", "Kicker? I Hardly Know Her"
- Add per-personality LLM system prompts giving each archetype a distinct
  voice (Rock=grizzled old-timer, Maniac=chaotic hype, Fish=lovable newbie, etc.)
- Make generate_chat async; try LLM nano first for dynamic in-character
  one-liners, fall back to template chat when no API key is configured
- Pass game context (community cards, pot) to chat generation for richer LLM responses
- Update tests for async generate_chat

https://claude.ai/code/session_01Vwi48Qei2HorqZLC9grmqV