### PR TITLE
Remove deck theme switcher from lobby, rotate deck styles per hand

### DIFF
--- a/frontend/src/components/common/PlayingCard.vue
+++ b/frontend/src/components/common/PlayingCard.vue
@@ -43,7 +43,6 @@
 
 <script setup>
 import { computed, ref, watch } from 'vue'
-import { useDeck } from '../../composables/useDeck'
 
 const props = defineProps({
   rank: { type: String, default: 'A' },
@@ -51,10 +50,10 @@ const props = defineProps({
   faceDown: { type: Boolean, default: false },
   size: { type: String, default: 'medium', validator: v => ['tiny', 'mini', 'small', 'medium', 'large'].includes(v) },
   /**
-   * Explicit deck override. When omitted the globally active deck from
-   * useDeck() is used. Pass 'css' to force the CSS/Unicode rendering.
+   * Card deck/art style. Defaults to 'css' (Unicode rendering).
+   * Pass 'classic', 'modern', or 'vintage' for image-based rendering.
    */
-  deck: { type: String, default: null },
+  deck: { type: String, default: 'css' },
   /**
    * Rotation in degrees applied to face-down cards to give a "dealt from
    * a deck" appearance. Positive = clockwise, negative = counter-clockwise.
@@ -62,10 +61,7 @@ const props = defineProps({
   rotation: { type: Number, default: 0 },
 })
 
-const { deck: globalDeck } = useDeck()
-
-// Resolved deck: explicit prop > global selection
-const activeDeck = computed(() => props.deck ?? globalDeck.value)
+const activeDeck = computed(() => props.deck)
 
 // Whether to attempt image rendering for this card
 const imgError = ref(false)

--- a/frontend/src/components/common/ThemeSwitcher.vue
+++ b/frontend/src/components/common/ThemeSwitcher.vue
@@ -13,34 +13,15 @@
         <span class="theme-label">{{ labels[t] }}</span>
       </button>
     </div>
-    <div class="deck-switcher">
-      <button
-        v-for="d in decks"
-        :key="d"
-        class="deck-btn"
-        :class="{ active: deck === d }"
-        :title="deckLabels[d]"
-        @click="setDeck(d)"
-      >
-        <span class="deck-icon">{{ deckIcons[d] }}</span>
-        <span class="deck-label">{{ deckLabels[d] }}</span>
-      </button>
-    </div>
   </div>
 </template>
 
 <script setup>
 import { useTheme } from '../../composables/useTheme'
-import { useDeck } from '../../composables/useDeck'
-
 const { theme, themes, setTheme } = useTheme()
-const { deck, decks, setDeck } = useDeck()
 
 const icons = { dark: '\u{1F319}', light: '\u{2600}', vintage: '\u{1F3B2}' }
 const labels = { dark: 'Dark', light: 'Light', vintage: 'Vintage' }
-
-const deckIcons = { css: '✦', classic: '♠', modern: '◆', vintage: '♣' }
-const deckLabels = { css: 'CSS', classic: 'Classic', modern: 'Modern', vintage: 'Vintage' }
 </script>
 
 <style scoped>
@@ -50,8 +31,7 @@ const deckLabels = { css: 'CSS', classic: 'Classic', modern: 'Modern', vintage: 
   gap: 4px;
 }
 
-.theme-switcher,
-.deck-switcher {
+.theme-switcher {
   display: flex;
   gap: 2px;
   background: var(--bg-input, rgba(255,255,255,0.03));
@@ -60,8 +40,7 @@ const deckLabels = { css: 'CSS', classic: 'Classic', modern: 'Modern', vintage: 
   border: 1px solid var(--border-panel, rgba(212,168,73,0.08));
 }
 
-.theme-btn,
-.deck-btn {
+.theme-btn {
   display: flex;
   align-items: center;
   gap: 0.25rem;
@@ -76,37 +55,31 @@ const deckLabels = { css: 'CSS', classic: 'Classic', modern: 'Modern', vintage: 
   transition: all 0.2s;
 }
 
-.theme-btn:hover,
-.deck-btn:hover {
+.theme-btn:hover {
   color: var(--text-secondary, #8a7e6b);
   background: var(--bg-hover, rgba(212,168,73,0.04));
 }
 
-.theme-btn.active,
-.deck-btn.active {
+.theme-btn.active {
   color: var(--accent, #d4a849);
   background: var(--accent-bg, rgba(212,168,73,0.06));
 }
 
-.theme-icon,
-.deck-icon {
+.theme-icon {
   font-size: 0.8rem;
   line-height: 1;
 }
 
-.theme-label,
-.deck-label {
+.theme-label {
   letter-spacing: 0.03em;
 }
 
 @media (max-width: 500px) {
-  .theme-label,
-  .deck-label {
+  .theme-label {
     display: none;
   }
 
-  .theme-btn,
-  .deck-btn {
+  .theme-btn {
     padding: 0.25rem 0.35rem;
   }
 }

--- a/frontend/src/components/holdem/PokerTable.vue
+++ b/frontend/src/components/holdem/PokerTable.vue
@@ -124,8 +124,8 @@
               <TransitionGroup name="card-deal">
                 <div v-for="(card, i) in communityCardSlots" :key="card.key" class="card-slot"
                   :class="{ 'is-dealt': card.dealt }" :style="{ '--deal-delay': `${i * 0.08}s` }">
-                  <PlayingCard v-if="card.dealt" :rank="card.rank" :suit="card.suit" size="large" />
-                  <PlayingCard v-else :faceDown="true" size="large" :rotation="deckRotation" />
+                  <PlayingCard v-if="card.dealt" :rank="card.rank" :suit="card.suit" size="large" :deck="handDeck" />
+                  <PlayingCard v-else :faceDown="true" size="large" :rotation="deckRotation" :deck="handDeck" />
                 </div>
               </TransitionGroup>
             </div>
@@ -155,7 +155,7 @@
         <div v-if="winnerBanner.playerHands && Object.keys(winnerBanner.playerHands).length" class="winner-banner-hands">
           <div v-if="winnerBanner.communityCards && winnerBanner.communityCards.length" class="banner-community-cards">
             <PlayingCard v-for="(c, i) in winnerBanner.communityCards" :key="'cc-' + i"
-              :rank="c.rank" :suit="c.suit" size="tiny" class="banner-mini-card" />
+              :rank="c.rank" :suit="c.suit" size="tiny" class="banner-mini-card" :deck="handDeck" />
           </div>
           <div class="banner-player-hands-row">
             <div v-for="(cards, pid) in winnerBanner.playerHands" :key="pid" class="banner-player-hand"
@@ -163,7 +163,7 @@
               <span class="banner-hand-name">{{ playerName(pid) }}</span>
               <div class="banner-hand-cards">
                 <PlayingCard v-for="(c, i) in cards" :key="c.rank + '-' + c.suit"
-                  :rank="c.rank" :suit="c.suit" size="tiny" class="banner-mini-card" />
+                  :rank="c.rank" :suit="c.suit" size="tiny" class="banner-mini-card" :deck="handDeck" />
               </div>
             </div>
           </div>
@@ -178,12 +178,12 @@
         <div class="hole-cards">
           <template v-if="yourCards.length">
             <PlayingCard v-for="(c, i) in yourCards" :key="i"
-              :rank="c.rank" :suit="c.suit" size="medium" class="hole-card"
+              :rank="c.rank" :suit="c.suit" size="medium" class="hole-card" :deck="handDeck"
               :style="{ '--tilt': i === 0 ? '-4deg' : '4deg', '--lift': i === 0 ? '0px' : '2px' }" />
           </template>
           <template v-else>
-            <PlayingCard :faceDown="true" size="medium" class="hole-card" :style="{ '--tilt': '-4deg' }" :rotation="deckRotation" />
-            <PlayingCard :faceDown="true" size="medium" class="hole-card" :style="{ '--tilt': '4deg' }" :rotation="deckRotation" />
+            <PlayingCard :faceDown="true" size="medium" class="hole-card" :style="{ '--tilt': '-4deg' }" :rotation="deckRotation" :deck="handDeck" />
+            <PlayingCard :faceDown="true" size="medium" class="hole-card" :style="{ '--tilt': '4deg' }" :rotation="deckRotation" :deck="handDeck" />
           </template>
         </div>
       </div>
@@ -336,7 +336,7 @@
             </div>
             <div v-if="showdownData.community_cards && showdownData.community_cards.length" class="showdown-community-cards">
               <PlayingCard v-for="(c, i) in showdownData.community_cards" :key="'sc-' + i"
-                :rank="c.rank" :suit="c.suit" size="mini" class="mini-card" />
+                :rank="c.rank" :suit="c.suit" size="mini" class="mini-card" :deck="handDeck" />
             </div>
             <div class="showdown-divider"></div>
             <div class="showdown-hands">
@@ -344,7 +344,7 @@
                 <span class="sh-name">{{ playerName(pid) }}</span>
                 <div class="sh-cards">
                   <PlayingCard v-for="(c, i) in cards" :key="i"
-                    :rank="c.rank" :suit="c.suit" size="mini" class="mini-card" />
+                    :rank="c.rank" :suit="c.suit" size="mini" class="mini-card" :deck="handDeck" />
                 </div>
               </div>
             </div>
@@ -479,6 +479,14 @@ const deckRotation = computed(() => {
   const h = props.gameState?.hand_number ?? 0
   const rotations = [-4, -2, 0, 2, 4, 3, -3, 1, -1]
   return rotations[h % rotations.length]
+})
+
+// Rotate through deck art styles each hand so players see variety without
+// needing a theme picker on the main page.
+const DECK_STYLES = ['css', 'classic', 'modern', 'vintage']
+const handDeck = computed(() => {
+  const h = props.gameState?.hand_number ?? 0
+  return DECK_STYLES[h % DECK_STYLES.length]
 })
 
 const communityCardSlots = computed(() => {


### PR DESCRIPTION
Instead of exposing a deck theme picker on the main page, the card art
style now rotates automatically each hand in Hold'em (css -> classic ->
modern -> vintage). This keeps visual variety without cluttering the UI.

- Remove deck switcher UI and related CSS from ThemeSwitcher.vue
- Remove global useDeck() dependency from PlayingCard.vue
- Add handDeck computed to PokerTable that cycles DECK_STYLES by hand_number
- Pass :deck="handDeck" to all PlayingCard instances in PokerTable

https://claude.ai/code/session_01Qe1KQhaExz7DaQNZmup9v6