### PR TITLE
Add black $20 chip denomination to Hold'em

### DIFF
--- a/backend/app/games/holdem/models.py
+++ b/backend/app/games/holdem/models.py
@@ -14,7 +14,7 @@ from pydantic import BaseModel, Field
 # ---------------------------------------------------------------------------
 
 # Chip denominations (GCD determines bet granularity)
-CHIP_DENOMINATIONS = [500, 100, 25, 10]
+CHIP_DENOMINATIONS = [2000, 500, 100, 25, 10]
 MIN_CHIP = reduce(gcd, CHIP_DENOMINATIONS)  # 5 — all bets must be multiples of this
 
 RANKS = ["2", "3", "4", "5", "6", "7", "8", "9", "10", "J", "Q", "K", "A"]

--- a/frontend/src/components/holdem/PokerTable.vue
+++ b/frontend/src/components/holdem/PokerTable.vue
@@ -396,6 +396,7 @@ const emit = defineEmits(['action', 'send-chat', 'rebuy', 'decline-rebuy'])
 
 // Chip denominations: value, color name (used as CSS class), and display color
 const CHIP_DENOMS = [
+  { value: 2000, color: 'black' },
   { value: 500, color: 'green' },
   { value: 100, color: 'blue' },
   { value: 25, color: 'red' },
@@ -1147,6 +1148,11 @@ watch(
 }
 
 /* ─── Chip denomination colors ─── */
+.chip-black {
+  background: #1a1a1a;
+  border-color: #444;
+}
+
 .chip-white {
   background: #e8e8e8;
   border-color: #bbb;


### PR DESCRIPTION
Adds a 2000-cent ($20) black chip to both backend and frontend chip
denomination lists, with corresponding CSS styling.

https://claude.ai/code/session_01RZ88Jz1Xw4C8ytyUCQvigj