### PR TITLE
Improve mobile card layout and readability across games

### DIFF
--- a/frontend/src/components/clue/GameBoard.vue
+++ b/frontend/src/components/clue/GameBoard.vue
@@ -2279,9 +2279,51 @@ watch(
     font-size: 0.8rem;
   }
 
+  /* Phone: switch hand cards to horizontal chip layout for readability */
+  .card-hand {
+    flex-direction: column;
+    gap: 0.25rem;
+  }
+
   .hand-card {
-    width: 68px;
-    font-size: 0.65rem;
+    width: 100%;
+    flex-direction: row;
+    gap: 0.4rem;
+    padding: 5px 8px;
+    border-radius: 8px;
+    font-size: 0.8rem;
+    align-items: center;
+  }
+
+  .hand-card .card-thumb {
+    width: 36px;
+    height: 36px;
+    border-radius: 50%;
+    object-position: center 15%;
+    flex-shrink: 0;
+  }
+
+  .hand-card .card-thumb.card-thumb-room {
+    border-radius: 6px;
+    object-position: center center;
+  }
+
+  .hand-card .card-thumb.card-thumb-weapon {
+    border-radius: 6px;
+    object-position: center center;
+  }
+
+  .hand-card .card-icon {
+    font-size: 1.3rem;
+    margin: 0;
+    flex-shrink: 0;
+  }
+
+  .hand-card .card-label {
+    font-size: 0.82rem;
+    white-space: nowrap;
+    text-align: left;
+    line-height: 1.2;
   }
 
   .physical-card-image-frame {
@@ -2293,17 +2335,37 @@ watch(
   }
 
   .game-over-cards {
-    gap: 0.75rem;
+    gap: 0.6rem;
   }
   .game-over-card.physical-card {
-    width: 100px;
+    width: 110px;
+  }
+  .game-over-card .physical-card-title {
+    font-size: 0.72rem;
   }
   .game-over-card-frame {
-    width: 85px;
-    height: 65px;
+    width: 90px;
+    height: 68px;
   }
   .game-over-banner {
-    padding: 1.5rem 1.5rem;
+    padding: 1.5rem 1rem;
+  }
+
+  /* Card shown banner on phone */
+  .card-shown-banner {
+    padding: 1.5rem 1.25rem;
+  }
+  .card-shown-banner-card.physical-card {
+    width: min(160px, 55vw);
+  }
+  .card-shown-banner-card.physical-card .physical-card-image-frame {
+    height: 100px;
+  }
+  .card-shown-banner-card.physical-card.card-suspect .physical-card-image-frame {
+    height: 100px;
+  }
+  .card-shown-banner-suggestion {
+    font-size: 0.82rem;
   }
 
   .legend-name,
@@ -2323,12 +2385,17 @@ watch(
   }
 
   .hand-card {
-    width: 60px;
-    font-size: 0.6rem;
+    padding: 4px 6px;
+    font-size: 0.75rem;
   }
 
-  .card-hand {
-    gap: 0.3rem;
+  .hand-card .card-thumb {
+    width: 30px;
+    height: 30px;
+  }
+
+  .hand-card .card-label {
+    font-size: 0.78rem;
   }
 
   .status-banner {

--- a/frontend/src/components/holdem/PokerTable.vue
+++ b/frontend/src/components/holdem/PokerTable.vue
@@ -2254,13 +2254,29 @@ watch(
   }
 
   .card-slot :deep(.playing-card) {
-    width: 44px;
-    height: 62px;
+    width: 48px;
+    height: 68px;
+  }
+
+  .card-slot :deep(.card-rank) {
+    font-size: 0.65rem;
+  }
+
+  .card-slot :deep(.card-suit-small) {
+    font-size: 0.5rem;
   }
 
   .hole-card {
-    width: 52px !important;
-    height: 74px !important;
+    width: 56px !important;
+    height: 80px !important;
+  }
+
+  .hole-card :deep(.card-rank) {
+    font-size: 0.7rem;
+  }
+
+  .hole-card :deep(.card-suit-small) {
+    font-size: 0.55rem;
   }
 
   .bottom-dock {


### PR DESCRIPTION
## Summary
This PR enhances the mobile UI for card displays across the Clue and Poker games by redesigning hand cards to use a horizontal chip layout and improving spacing and sizing for better readability on smaller screens.

## Key Changes

**GameBoard.vue (Clue game):**
- Redesigned hand cards from vertical layout to horizontal chip-style layout with card thumbnail, icon, and label
- Added dedicated styling for card thumbnails with appropriate border-radius (circular for suspects, rounded for rooms/weapons)
- Improved hand card spacing and padding for better touch targets
- Enhanced game-over card display with adjusted sizing (100px → 110px width) and spacing
- Added styling for card-shown banner with responsive sizing using `min(160px, 55vw)`
- Updated font sizes across card elements for improved readability (0.8rem for hand cards, 0.82rem for labels)
- Adjusted padding in game-over banner (1.5rem 1.5rem → 1.5rem 1rem) for better space utilization
- Added tablet-specific adjustments with smaller padding and font sizes

**PokerTable.vue (Holdem game):**
- Increased playing card dimensions for better visibility (44px → 48px width, 62px → 68px height)
- Increased hole card dimensions (52px → 56px width, 74px → 80px height)
- Added explicit font sizing for card rank and suit elements to maintain readability at new sizes
- Improved visual hierarchy with consistent sizing adjustments across different card contexts

## Implementation Details
- Hand cards now use flexbox with `flex-direction: row` to display thumbnail, icon, and label horizontally
- Card thumbnails use `flex-shrink: 0` to prevent compression
- Responsive sizing uses CSS `min()` function for card-shown banner to adapt to viewport width
- Maintained consistent spacing patterns with gap adjustments (0.3rem → 0.25rem for phone, 0.6rem for game-over)
- All changes are mobile-first with tablet-specific overrides for smaller screens

https://claude.ai/code/session_01L19hiZaBg1cQNjaUU8yJDt