### PR TITLE
Add player tracking to detective notes for suggestion deductions

### DIFF
--- a/frontend/src/App.vue
+++ b/frontend/src/App.vue
@@ -12,7 +12,7 @@
         @game-started="onGameStarted" @leave-game="leaveGame" />
       <GameBoard v-else :game-id="gameId" :player-id="playerId" :game-state="gameState" :board-data="boardData"
         :your-cards="yourCards" :available-actions="availableActions" :show-card-request="showCardRequest"
-        :card-shown="cardShown" :chat-messages="chatMessages" :is-observer="isObserver" :auto-end-timer="autoEndTimer"
+        :card-shown="cardShown" :suggestion-tracking="suggestionTracking" :chat-messages="chatMessages" :is-observer="isObserver" :auto-end-timer="autoEndTimer"
         :auto-show-card-timer="autoShowCardTimer" :reachable-rooms="reachableRooms"
         :reachable-positions="reachablePositions" :saved-notes="savedNotes" :agent-debug-data="agentDebugData"
         :observer-player-state="observerPlayerState" @action="sendAction" @send-chat="sendChat"
@@ -50,6 +50,7 @@ const yourCards = ref([])
 const availableActions = ref([])
 const showCardRequest = ref(null)
 const cardShown = ref(null)
+const suggestionTracking = ref(null)
 const chatMessages = ref([])
 const isObserver = ref(false)
 const urlGameId = ref(null)
@@ -428,6 +429,14 @@ function handleMessage(msg) {
         if (!msg.pending_show_by && msg.player_id === playerId.value) {
           cardShown.value = { card: null, by: null, suspect: msg.suspect, weapon: msg.weapon, room: msg.room }
         }
+        // Track negative knowledge: players who couldn't show any of the suggested cards
+        if (msg.players_without_match?.length) {
+          suggestionTracking.value = {
+            players_without_match: msg.players_without_match,
+            cards: [msg.suspect, msg.weapon, msg.room],
+            _ts: Date.now()
+          }
+        }
       }
       break
 
@@ -507,6 +516,7 @@ function resetState() {
   availableActions.value = []
   showCardRequest.value = null
   cardShown.value = null
+  suggestionTracking.value = null
   chatMessages.value = []
   isObserver.value = false
   autoEndTimer.value = null

--- a/frontend/src/components/clue/DetectiveNotes.vue
+++ b/frontend/src/components/clue/DetectiveNotes.vue
@@ -2,6 +2,15 @@
   <div class="detective-notes">
     <h3 class="panel-header">Detective Notes</h3>
 
+    <!-- Player column legend -->
+    <div v-if="trackedPlayers.length" class="player-columns-legend">
+      <div class="legend-spacer"></div>
+      <div v-for="p in trackedPlayers" :key="p.id" class="player-col-header"
+        :title="p.name + (p.character !== p.name ? ' (' + p.character + ')' : '')">
+        {{ playerInitial(p) }}
+      </div>
+    </div>
+
     <div class="notes-section">
       <h4>Suspects</h4>
       <div v-for="card in SUSPECTS" :key="card" class="note-row" :class="noteClass(card)" @click="cycleNote(card)">
@@ -13,6 +22,12 @@
           <span v-if="notes[card] === 'seen' && shownByMap[card]" class="note-tooltip">Shown by {{ shownByMap[card]
             }}</span>
         </span>
+        <template v-if="trackedPlayers.length">
+          <span v-for="p in trackedPlayers" :key="p.id" class="player-col-cell"
+            :class="{ 'doesnt-have': playerDoesntHave[p.id]?.[card] }">
+            {{ playerDoesntHave[p.id]?.[card] ? '\u2717' : '' }}
+          </span>
+        </template>
       </div>
     </div>
 
@@ -27,6 +42,12 @@
           <span v-if="notes[card] === 'seen' && shownByMap[card]" class="note-tooltip">Shown by {{ shownByMap[card]
             }}</span>
         </span>
+        <template v-if="trackedPlayers.length">
+          <span v-for="p in trackedPlayers" :key="p.id" class="player-col-cell"
+            :class="{ 'doesnt-have': playerDoesntHave[p.id]?.[card] }">
+            {{ playerDoesntHave[p.id]?.[card] ? '\u2717' : '' }}
+          </span>
+        </template>
       </div>
     </div>
 
@@ -41,13 +62,19 @@
           <span v-if="notes[card] === 'seen' && shownByMap[card]" class="note-tooltip">Shown by {{ shownByMap[card]
             }}</span>
         </span>
+        <template v-if="trackedPlayers.length">
+          <span v-for="p in trackedPlayers" :key="p.id" class="player-col-cell"
+            :class="{ 'doesnt-have': playerDoesntHave[p.id]?.[card] }">
+            {{ playerDoesntHave[p.id]?.[card] ? '\u2717' : '' }}
+          </span>
+        </template>
       </div>
     </div>
   </div>
 </template>
 
 <script setup>
-import { reactive, watch } from 'vue'
+import { reactive, computed, watch } from 'vue'
 import {
   SUSPECTS,
   WEAPONS,
@@ -62,7 +89,9 @@ const CYCLE = ['', 'no', 'maybe', '']
 
 const props = defineProps({
   yourCards: { type: Array, default: () => [] },
-  savedNotes: { type: Object, default: null }
+  savedNotes: { type: Object, default: null },
+  players: { type: Array, default: () => [] },
+  playerId: { type: String, default: '' }
 })
 
 const emit = defineEmits(['notes-changed'])
@@ -71,8 +100,19 @@ const emit = defineEmits(['notes-changed'])
 const notes = reactive({})
 // Track who showed each card
 const shownByMap = reactive({})
+// Track which cards each player definitely doesn't have: { playerId: { card: true } }
+const playerDoesntHave = reactive({})
 // Flag to prevent emitting during restoration
 let restoring = false
+
+// Non-wandering players other than ourselves
+const trackedPlayers = computed(() =>
+  props.players.filter(p => p.type !== 'wanderer' && p.id !== props.playerId)
+)
+
+function playerInitial(p) {
+  return (p.name || p.character || '?')[0].toUpperCase()
+}
 
 // Restore saved notes when they arrive (e.g. on rejoin)
 watch(
@@ -82,11 +122,15 @@ watch(
       restoring = true
       const noteStates = saved.notes || {}
       const shownBy = saved.shownBy || {}
+      const doesntHave = saved.playerDoesntHave || {}
       for (const [card, state] of Object.entries(noteStates)) {
         notes[card] = state
       }
       for (const [card, by] of Object.entries(shownBy)) {
         shownByMap[card] = by
+      }
+      for (const [pid, cards] of Object.entries(doesntHave)) {
+        playerDoesntHave[pid] = { ...cards }
       }
       restoring = false
     }
@@ -107,14 +151,21 @@ watch(
 
 function emitNotesChanged() {
   if (restoring) return
+  // Deep-copy playerDoesntHave
+  const doesntHaveCopy = {}
+  for (const [pid, cards] of Object.entries(playerDoesntHave)) {
+    doesntHaveCopy[pid] = { ...cards }
+  }
   emit('notes-changed', {
     notes: { ...notes },
-    shownBy: { ...shownByMap }
+    shownBy: { ...shownByMap },
+    playerDoesntHave: doesntHaveCopy
   })
 }
 
 // Watch for any notes changes and emit
 watch(notes, () => emitNotesChanged(), { deep: true })
+watch(playerDoesntHave, () => emitNotesChanged(), { deep: true })
 
 function noteMark(card) {
   const state = notes[card] ?? ''
@@ -167,7 +218,17 @@ function getCardsShownBy(playerName) {
   return cards
 }
 
-defineExpose({ markCard, getCardsShownBy })
+// Mark that a player doesn't have specific cards (from suggestion tracking)
+function markPlayerDoesntHaveCards(playerId, cards) {
+  if (!playerDoesntHave[playerId]) {
+    playerDoesntHave[playerId] = {}
+  }
+  for (const card of cards) {
+    playerDoesntHave[playerId][card] = true
+  }
+}
+
+defineExpose({ markCard, getCardsShownBy, markPlayerDoesntHaveCards })
 </script>
 
 <style scoped>
@@ -352,5 +413,45 @@ h4 {
 
 .note-mark.has-tooltip:hover .note-tooltip {
   display: block;
+}
+
+/* Player column tracking */
+.player-columns-legend {
+  display: flex;
+  justify-content: flex-end;
+  gap: 0;
+  padding: 0 0.3rem;
+  margin-bottom: 0.2rem;
+  border-bottom: 1px solid var(--accent-border);
+  padding-bottom: 0.15rem;
+}
+
+.legend-spacer {
+  flex: 1;
+}
+
+.player-col-header {
+  width: 20px;
+  text-align: center;
+  font-size: 0.6rem;
+  font-weight: 700;
+  text-transform: uppercase;
+  color: var(--text-secondary);
+  cursor: help;
+  flex-shrink: 0;
+}
+
+.player-col-cell {
+  width: 20px;
+  text-align: center;
+  font-size: 0.6rem;
+  font-weight: bold;
+  flex-shrink: 0;
+  color: var(--text-faint);
+}
+
+.player-col-cell.doesnt-have {
+  color: var(--error);
+  opacity: 0.7;
 }
 </style>

--- a/frontend/src/components/clue/GameBoard.vue
+++ b/frontend/src/components/clue/GameBoard.vue
@@ -328,6 +328,7 @@
         <!-- Detective Notes -->
         <section v-if="!isObserver" class="sidebar-panel notes-panel">
           <DetectiveNotes ref="notesRef" :your-cards="yourCards" :saved-notes="savedNotes"
+            :players="gameState?.players || []" :player-id="playerId"
             @notes-changed="onNotesChanged" />
         </section>
 
@@ -530,6 +531,7 @@ const props = defineProps({
   availableActions: { type: Array, default: () => [] },
   showCardRequest: Object,
   cardShown: Object,
+  suggestionTracking: { type: Object, default: null },
   chatMessages: { type: Array, default: () => [] },
   isObserver: { type: Boolean, default: false },
   autoEndTimer: { type: Object, default: null },
@@ -798,6 +800,18 @@ watch(
       cardShownDismissedOnce.value = false
       if (shown.card && notesRef.value) {
         notesRef.value.markCard(shown.card, 'seen', playerName(shown.by))
+      }
+    }
+  }
+)
+
+// Track negative knowledge from suggestions
+watch(
+  () => props.suggestionTracking,
+  (tracking) => {
+    if (tracking && notesRef.value) {
+      for (const pid of tracking.players_without_match) {
+        notesRef.value.markPlayerDoesntHaveCards(pid, tracking.cards)
       }
     }
   }


### PR DESCRIPTION
## Summary
This PR adds the ability to track which players don't have specific cards based on suggestion outcomes. When a suggestion is made and players can't show any of the suggested cards, the detective notes now display this negative knowledge in a new player column grid, helping players deduce card locations more effectively.

## Key Changes
- **Detective Notes Enhancement**: Added a new player column legend and tracking cells that display which players definitely don't have specific cards (marked with ✗)
  - New `playerDoesntHave` reactive object tracks negative knowledge per player
  - New `trackedPlayers` computed property filters to non-wanderer players (excluding self)
  - Added `markPlayerDoesntHaveCards()` method to record when players can't show cards

- **Suggestion Tracking Integration**: Connected suggestion outcomes to detective notes
  - `GameBoard` now watches `suggestionTracking` prop and updates notes when players can't match suggestions
  - Tracks `players_without_match` from suggestion messages to mark cards they don't have

- **State Management**: Extended note persistence to include player tracking data
  - `playerDoesntHave` state is now saved and restored with other notes
  - Added deep-copy logic to properly emit state changes

- **UI Styling**: Added CSS for player column display
  - Legend header showing player initials with tooltips
  - Tracking cells with error color highlighting for "doesn't have" markers
  - Responsive flex layout aligned with existing note rows

## Implementation Details
- Player columns only appear for non-wanderer players (excluding the current player)
- Player initials are derived from name or character, with fallback to '?'
- Negative knowledge is persisted in the saved notes structure under `playerDoesntHave`
- The tracking integrates seamlessly with existing note cycling and display logic

https://claude.ai/code/session_01QQ7GeK8AxVk67jaRdPTHkh