### PR TITLE
Improve UI layout: move player legend to sidebar, compact chat section

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1860,6 +1860,83 @@
         "@types/estree": "^1.0.0"
       }
     },
+    "node_modules/@vitest/browser-playwright/node_modules/vite": {
+      "version": "7.3.1",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-7.3.1.tgz",
+      "integrity": "sha512-w+N7Hifpc3gRjZ63vYBXA56dvvRlNWRczTdmCBBa+CotUzAPf5b7YMdMR/8CQoeYE5LX3W4wj6RYTgonm1b9DA==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "esbuild": "^0.27.0",
+        "fdir": "^6.5.0",
+        "picomatch": "^4.0.3",
+        "postcss": "^8.5.6",
+        "rollup": "^4.43.0",
+        "tinyglobby": "^0.2.15"
+      },
+      "bin": {
+        "vite": "bin/vite.js"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      },
+      "funding": {
+        "url": "https://github.com/vitejs/vite?sponsor=1"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      },
+      "peerDependencies": {
+        "@types/node": "^20.19.0 || >=22.12.0",
+        "jiti": ">=1.21.0",
+        "less": "^4.0.0",
+        "lightningcss": "^1.21.0",
+        "sass": "^1.70.0",
+        "sass-embedded": "^1.70.0",
+        "stylus": ">=0.54.8",
+        "sugarss": "^5.0.0",
+        "terser": "^5.16.0",
+        "tsx": "^4.8.1",
+        "yaml": "^2.4.2"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        },
+        "jiti": {
+          "optional": true
+        },
+        "less": {
+          "optional": true
+        },
+        "lightningcss": {
+          "optional": true
+        },
+        "sass": {
+          "optional": true
+        },
+        "sass-embedded": {
+          "optional": true
+        },
+        "stylus": {
+          "optional": true
+        },
+        "sugarss": {
+          "optional": true
+        },
+        "terser": {
+          "optional": true
+        },
+        "tsx": {
+          "optional": true
+        },
+        "yaml": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@vitest/browser/node_modules/@vitest/mocker": {
       "version": "4.0.18",
       "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-4.0.18.tgz",
@@ -1895,6 +1972,83 @@
       "license": "MIT",
       "dependencies": {
         "@types/estree": "^1.0.0"
+      }
+    },
+    "node_modules/@vitest/browser/node_modules/vite": {
+      "version": "7.3.1",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-7.3.1.tgz",
+      "integrity": "sha512-w+N7Hifpc3gRjZ63vYBXA56dvvRlNWRczTdmCBBa+CotUzAPf5b7YMdMR/8CQoeYE5LX3W4wj6RYTgonm1b9DA==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "esbuild": "^0.27.0",
+        "fdir": "^6.5.0",
+        "picomatch": "^4.0.3",
+        "postcss": "^8.5.6",
+        "rollup": "^4.43.0",
+        "tinyglobby": "^0.2.15"
+      },
+      "bin": {
+        "vite": "bin/vite.js"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      },
+      "funding": {
+        "url": "https://github.com/vitejs/vite?sponsor=1"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      },
+      "peerDependencies": {
+        "@types/node": "^20.19.0 || >=22.12.0",
+        "jiti": ">=1.21.0",
+        "less": "^4.0.0",
+        "lightningcss": "^1.21.0",
+        "sass": "^1.70.0",
+        "sass-embedded": "^1.70.0",
+        "stylus": ">=0.54.8",
+        "sugarss": "^5.0.0",
+        "terser": "^5.16.0",
+        "tsx": "^4.8.1",
+        "yaml": "^2.4.2"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        },
+        "jiti": {
+          "optional": true
+        },
+        "less": {
+          "optional": true
+        },
+        "lightningcss": {
+          "optional": true
+        },
+        "sass": {
+          "optional": true
+        },
+        "sass-embedded": {
+          "optional": true
+        },
+        "stylus": {
+          "optional": true
+        },
+        "sugarss": {
+          "optional": true
+        },
+        "terser": {
+          "optional": true
+        },
+        "tsx": {
+          "optional": true
+        },
+        "yaml": {
+          "optional": true
+        }
       }
     },
     "node_modules/@vitest/coverage-v8": {

--- a/frontend/src/components/clue/ChatPanel.vue
+++ b/frontend/src/components/clue/ChatPanel.vue
@@ -1,26 +1,29 @@
 <template>
   <div class="chat-panel">
-    <div class="log-filters">
-      <label class="filter-label">
-        <input type="checkbox" v-model="showSuggestions" />
-        Suggestions
-      </label>
-      <label class="filter-label">
-        <input type="checkbox" v-model="showCardShows" />
-        Card Shows
-      </label>
-      <label class="filter-label">
-        <input type="checkbox" v-model="showAccusations" />
-        Accusations
-      </label>
-      <label class="filter-label">
-        <input type="checkbox" v-model="showMoves" />
-        Moves &amp; Rolls
-      </label>
-      <label class="filter-label">
-        <input type="checkbox" v-model="showChat" />
-        Chat
-      </label>
+    <div class="chat-header-row">
+      <h2 class="panel-header chat-title">Chat &amp; Game Log</h2>
+      <div class="log-filters">
+        <label class="filter-label">
+          <input type="checkbox" v-model="showSuggestions" />
+          Suggestions
+        </label>
+        <label class="filter-label">
+          <input type="checkbox" v-model="showCardShows" />
+          Card Shows
+        </label>
+        <label class="filter-label">
+          <input type="checkbox" v-model="showAccusations" />
+          Accusations
+        </label>
+        <label class="filter-label">
+          <input type="checkbox" v-model="showMoves" />
+          Moves &amp; Rolls
+        </label>
+        <label class="filter-label">
+          <input type="checkbox" v-model="showChat" />
+          Chat
+        </label>
+      </div>
     </div>
 
     <ul class="chat-messages" ref="chatContainer">
@@ -207,12 +210,24 @@ watch(
   font-family: 'Crimson Text', Georgia, serif;
 }
 
+.chat-header-row {
+  display: flex;
+  align-items: center;
+  gap: 0.8rem;
+  margin-bottom: 0.3rem;
+}
+
+.chat-title {
+  margin: 0;
+  white-space: nowrap;
+  flex-shrink: 0;
+}
+
 .log-filters {
   display: flex;
   flex-wrap: wrap;
-  gap: 0.4rem 0.8rem;
-  margin-bottom: 0.4rem;
-  padding: 0.3rem 0;
+  gap: 0.2rem 0.6rem;
+  padding: 0;
 }
 
 .filter-label {
@@ -238,7 +253,7 @@ watch(
   flex: 1;
   overflow-y: auto;
   max-height: 200px;
-  margin-bottom: 0.5rem;
+  margin-bottom: 0.3rem;
   padding-right: 0.2rem;
 }
 

--- a/frontend/src/components/clue/GameBoard.vue
+++ b/frontend/src/components/clue/GameBoard.vue
@@ -76,44 +76,6 @@
             </div>
           </div>
         </div>
-
-        <!-- Player Legend -->
-        <div class="player-legend">
-          <div v-for="p in gameState?.players" :key="p.id" class="legend-item" :class="{
-            active: gameState?.whose_turn === p.id,
-            eliminated: !p.active,
-            'is-me': p.id === playerId,
-            'wanderer-legend': p.type === 'wanderer',
-            'observer-clickable': isObserver,
-            'observer-selected': isObserver && observerPlayerState?.playerId === p.id
-          }" @click.stop="onLegendClick(p)">
-            <PlayerPawn :character="p.character" :wanderer="p.type === 'wanderer'" />
-            <span class="legend-name">{{ p.name }}</span>
-            <span v-if="p.type !== 'wanderer' && p.character !== p.name" class="legend-character">{{ p.character }}</span>
-            <span v-if="gameState?.current_room?.[p.id]" class="legend-room">{{
-              gameState.current_room[p.id]
-              }}</span>
-            <span v-if="!p.active" class="legend-status">eliminated</span>
-            <span v-if="p.type === 'wanderer'" class="legend-wanderer-label">wandering</span>
-            <span v-else-if="gameState?.whose_turn === p.id" class="legend-turn">turn</span>
-            <!-- Shown cards popup -->
-            <div v-if="shownCardsPlayerId === p.id && shownCardsForPlayer.length" class="shown-cards-popup" @click.stop>
-              <div class="shown-cards-title">Cards shown to you:</div>
-              <div class="shown-cards-hand">
-                <div v-for="card in shownCardsForPlayer" :key="card" class="hand-card" :class="cardCategory(card)" :title="card">
-                  <img v-if="hasCardImage(card)" :src="cardImageUrl(card)" :alt="card" class="card-thumb" />
-                  <span v-else class="card-icon">{{ cardIcon(card) }}</span>
-                  <span class="card-label">{{ card }}</span>
-                </div>
-              </div>
-            </div>
-            <div v-if="shownCardsPlayerId === p.id && !shownCardsForPlayer.length" class="shown-cards-popup"
-              @click.stop>
-              <div class="shown-cards-title">No cards shown to you</div>
-            </div>
-          </div>
-        </div>
-
       </div>
 
       <!-- Right: Sidebar -->
@@ -147,6 +109,46 @@
                   class="card-thumb card-thumb-room" />
                 <span v-else class="card-icon">{{ cardIcon(card) }}</span>
                 <span class="card-label">{{ card }}</span>
+              </div>
+            </div>
+          </div>
+        </section>
+
+        <!-- Player Legend (Turn Order) -->
+        <section class="sidebar-panel player-legend-panel">
+          <h2 class="panel-header collapsible-header" @click="legendCollapsed = !legendCollapsed">
+            <span>Players</span>
+            <span class="collapse-indicator" :class="{ collapsed: legendCollapsed }">&#9660;</span>
+          </h2>
+          <div v-if="!legendCollapsed" class="player-legend">
+            <div v-for="p in gameState?.players" :key="p.id" class="legend-item" :class="{
+              active: gameState?.whose_turn === p.id,
+              eliminated: !p.active,
+              'is-me': p.id === playerId,
+              'wanderer-legend': p.type === 'wanderer',
+              'observer-clickable': isObserver,
+              'observer-selected': isObserver && observerPlayerState?.playerId === p.id
+            }" @click.stop="onLegendClick(p)">
+              <PlayerPawn :character="p.character" :wanderer="p.type === 'wanderer'" />
+              <span class="legend-name">{{ p.name }}</span>
+              <span v-if="p.type !== 'wanderer' && p.character !== p.name" class="legend-character">{{ p.character }}</span>
+              <span v-if="gameState?.current_room?.[p.id]" class="legend-room">{{ gameState.current_room[p.id] }}</span>
+              <span v-if="!p.active" class="legend-status">eliminated</span>
+              <span v-if="p.type === 'wanderer'" class="legend-wanderer-label">wandering</span>
+              <span v-else-if="gameState?.whose_turn === p.id" class="legend-turn">turn</span>
+              <!-- Shown cards popup -->
+              <div v-if="shownCardsPlayerId === p.id && shownCardsForPlayer.length" class="shown-cards-popup" @click.stop>
+                <div class="shown-cards-title">Cards shown to you:</div>
+                <div class="shown-cards-hand">
+                  <div v-for="card in shownCardsForPlayer" :key="card" class="hand-card" :class="cardCategory(card)" :title="card">
+                    <img v-if="hasCardImage(card)" :src="cardImageUrl(card)" :alt="card" class="card-thumb" />
+                    <span v-else class="card-icon">{{ cardIcon(card) }}</span>
+                    <span class="card-label">{{ card }}</span>
+                  </div>
+                </div>
+              </div>
+              <div v-if="shownCardsPlayerId === p.id && !shownCardsForPlayer.length" class="shown-cards-popup" @click.stop>
+                <div class="shown-cards-title">No cards shown to you</div>
               </div>
             </div>
           </div>
@@ -378,7 +380,6 @@
 
       <!-- Chat (at bottom of responsive stack) -->
       <section class="sidebar-panel chat-panel-wrapper">
-        <h2 class="panel-header">Chat &amp; Game Log</h2>
         <ChatPanel
           :messages="chatMessages"
           :players="gameState?.players"
@@ -555,6 +556,7 @@ const accuseWeapon = ref('')
 const accuseRoom = ref('')
 const showAccuseForm = ref(false)
 const cardsCollapsed = ref(false)
+const legendCollapsed = ref(false)
 
 // Auto-end timer countdown
 const countdown = ref(null)
@@ -976,22 +978,22 @@ watch(
   gap: 0.5rem;
 }
 
-/* Player legend */
+/* Player legend (sidebar vertical list) */
+.player-legend-panel {
+  padding: 0.4rem 0.6rem;
+}
+
 .player-legend {
-  background: var(--bg-panel);
-  border: 1px solid var(--border-panel);
-  border-radius: 6px;
-  padding: 0.5rem 0.75rem;
   display: flex;
-  flex-wrap: wrap;
-  gap: 0.4rem;
+  flex-direction: column;
+  gap: 0.15rem;
 }
 
 .legend-item {
   display: flex;
   align-items: center;
   gap: 0.35rem;
-  padding: 0.2rem 0.5rem;
+  padding: 0.15rem 0.4rem;
   border-radius: 4px;
   font-size: 0.75rem;
   background: rgba(255, 255, 255, 0.02);
@@ -1617,8 +1619,8 @@ watch(
 
 /* Chat */
 .chat-panel-wrapper {
-  min-height: 200px;
-  grid-column: 1;
+  min-height: 160px;
+  grid-column: 1 / -1;
 }
 
 /* Card thumbnails in hand */


### PR DESCRIPTION
- Move player legend from below the board into the sidebar as a
  collapsible vertical list, reducing horizontal space usage
- Integrate chat filter checkboxes inline with the "Chat & Game Log"
  header instead of a separate row
- Reduce chat section spacing to show content sooner
- Chat panel now spans full width below board and sidebar

https://claude.ai/code/session_01RHwwQtRPEEy21xw1xcaHCP