### PR TITLE
Add player mark cycling and auto-fill toggle to Detective Notes

### DIFF
--- a/frontend/src/components/clue/DetectiveNotes.vue
+++ b/frontend/src/components/clue/DetectiveNotes.vue
@@ -29,11 +29,16 @@
             }}</span>
         </span>
         <template v-if="trackedPlayers.length">
-          <span v-for="p in trackedPlayers" :key="p.id" class="player-col-cell"
+          <button
+            v-for="p in trackedPlayers"
+            :key="p.id"
+            type="button"
+            class="player-col-cell"
             :class="playerCellClass(p.id, card)"
-            @click.stop="cyclePlayerMark(p.id, card)">
+            @click.stop="cyclePlayerMark(p.id, card)"
+          >
             {{ playerMarkDisplay(p.id, card) }}
-          </span>
+          </button>
         </template>
       </div>
     </div>
@@ -50,11 +55,16 @@
             }}</span>
         </span>
         <template v-if="trackedPlayers.length">
-          <span v-for="p in trackedPlayers" :key="p.id" class="player-col-cell"
+          <button
+            v-for="p in trackedPlayers"
+            :key="p.id"
+            type="button"
+            class="player-col-cell"
             :class="playerCellClass(p.id, card)"
-            @click.stop="cyclePlayerMark(p.id, card)">
+            @click.stop="cyclePlayerMark(p.id, card)"
+          >
             {{ playerMarkDisplay(p.id, card) }}
-          </span>
+          </button>
         </template>
       </div>
     </div>
@@ -71,11 +81,16 @@
             }}</span>
         </span>
         <template v-if="trackedPlayers.length">
-          <span v-for="p in trackedPlayers" :key="p.id" class="player-col-cell"
+          <button
+            v-for="p in trackedPlayers"
+            :key="p.id"
+            type="button"
+            class="player-col-cell"
             :class="playerCellClass(p.id, card)"
-            @click.stop="cyclePlayerMark(p.id, card)">
+            @click.stop="cyclePlayerMark(p.id, card)"
+          >
             {{ playerMarkDisplay(p.id, card) }}
-          </span>
+          </button>
         </template>
       </div>
     </div>

--- a/frontend/src/components/clue/DetectiveNotes.vue
+++ b/frontend/src/components/clue/DetectiveNotes.vue
@@ -201,9 +201,9 @@ function emitNotesChanged() {
 }
 
 // Watch for any notes changes and emit
-watch(notes, () => emitNotesChanged(), { deep: true })
-watch(playerDoesntHave, () => emitNotesChanged(), { deep: true })
-watch(autoFillEnabled, () => emitNotesChanged())
+watch(notes, () => emitNotesChanged(), { deep: true, flush: 'sync' })
+watch(playerDoesntHave, () => emitNotesChanged(), { deep: true, flush: 'sync' })
+watch(autoFillEnabled, () => emitNotesChanged(), { flush: 'sync' })
 
 function noteMark(card) {
   const state = notes[card] ?? ''

--- a/frontend/src/components/clue/DetectiveNotes.vue
+++ b/frontend/src/components/clue/DetectiveNotes.vue
@@ -126,6 +126,8 @@ const notes = reactive({})
 const shownByMap = reactive({})
 // Track player marks per card: { playerId: { card: '✗'|'✓'|'?' } }
 const playerDoesntHave = reactive({})
+// Prefer using `playerMarks` as the clearer name; kept `playerDoesntHave` for backward compatibility.
+const playerMarks = playerDoesntHave
 // Whether auto-fill from suggestions is enabled
 const autoFillEnabled = ref(true)
 // Symbols for player column cycling
@@ -150,7 +152,8 @@ watch(
       restoring = true
       const noteStates = saved.notes || {}
       const shownBy = saved.shownBy || {}
-      const doesntHave = saved.playerDoesntHave || {}
+      // Prefer `playerMarks` if present, fall back to legacy `playerDoesntHave`
+      const doesntHave = saved.playerMarks || saved.playerDoesntHave || {}
       for (const [card, state] of Object.entries(noteStates)) {
         notes[card] = state
       }
@@ -163,7 +166,7 @@ watch(
         for (const [card, val] of Object.entries(cards)) {
           converted[card] = val === true ? '\u2717' : val
         }
-        playerDoesntHave[pid] = converted
+        playerMarks[pid] = converted
       }
       if (saved.autoFillEnabled !== undefined) {
         autoFillEnabled.value = saved.autoFillEnabled

--- a/frontend/src/components/clue/DetectiveNotes.vue
+++ b/frontend/src/components/clue/DetectiveNotes.vue
@@ -2,7 +2,13 @@
   <div class="detective-notes">
     <h3 class="panel-header">Detective Notes</h3>
 
-    <!-- Player column legend -->
+    <!-- Auto-fill toggle + Player column legend -->
+    <div v-if="trackedPlayers.length" class="autofill-row">
+      <label class="autofill-label">
+        <input type="checkbox" v-model="autoFillEnabled" class="autofill-checkbox" />
+        Auto-fill from suggestions
+      </label>
+    </div>
     <div v-if="trackedPlayers.length" class="player-columns-legend">
       <div class="legend-spacer"></div>
       <div v-for="p in trackedPlayers" :key="p.id" class="player-col-header"
@@ -24,8 +30,9 @@
         </span>
         <template v-if="trackedPlayers.length">
           <span v-for="p in trackedPlayers" :key="p.id" class="player-col-cell"
-            :class="{ 'doesnt-have': playerDoesntHave[p.id]?.[card] }">
-            {{ playerDoesntHave[p.id]?.[card] ? '\u2717' : '' }}
+            :class="playerCellClass(p.id, card)"
+            @click.stop="cyclePlayerMark(p.id, card)">
+            {{ playerMarkDisplay(p.id, card) }}
           </span>
         </template>
       </div>
@@ -44,8 +51,9 @@
         </span>
         <template v-if="trackedPlayers.length">
           <span v-for="p in trackedPlayers" :key="p.id" class="player-col-cell"
-            :class="{ 'doesnt-have': playerDoesntHave[p.id]?.[card] }">
-            {{ playerDoesntHave[p.id]?.[card] ? '\u2717' : '' }}
+            :class="playerCellClass(p.id, card)"
+            @click.stop="cyclePlayerMark(p.id, card)">
+            {{ playerMarkDisplay(p.id, card) }}
           </span>
         </template>
       </div>
@@ -64,8 +72,9 @@
         </span>
         <template v-if="trackedPlayers.length">
           <span v-for="p in trackedPlayers" :key="p.id" class="player-col-cell"
-            :class="{ 'doesnt-have': playerDoesntHave[p.id]?.[card] }">
-            {{ playerDoesntHave[p.id]?.[card] ? '\u2717' : '' }}
+            :class="playerCellClass(p.id, card)"
+            @click.stop="cyclePlayerMark(p.id, card)">
+            {{ playerMarkDisplay(p.id, card) }}
           </span>
         </template>
       </div>
@@ -74,7 +83,7 @@
 </template>
 
 <script setup>
-import { reactive, computed, watch } from 'vue'
+import { reactive, ref, computed, watch } from 'vue'
 import {
   SUSPECTS,
   WEAPONS,
@@ -100,8 +109,12 @@ const emit = defineEmits(['notes-changed'])
 const notes = reactive({})
 // Track who showed each card
 const shownByMap = reactive({})
-// Track which cards each player definitely doesn't have: { playerId: { card: true } }
+// Track player marks per card: { playerId: { card: '✗'|'✓'|'?' } }
 const playerDoesntHave = reactive({})
+// Whether auto-fill from suggestions is enabled
+const autoFillEnabled = ref(true)
+// Symbols for player column cycling
+const PLAYER_MARK_CYCLE = ['', '\u2717', '\u2713', '?']
 // Flag to prevent emitting during restoration
 let restoring = false
 
@@ -130,7 +143,15 @@ watch(
         shownByMap[card] = by
       }
       for (const [pid, cards] of Object.entries(doesntHave)) {
-        playerDoesntHave[pid] = { ...cards }
+        // Backward compat: convert boolean `true` to '✗'
+        const converted = {}
+        for (const [card, val] of Object.entries(cards)) {
+          converted[card] = val === true ? '\u2717' : val
+        }
+        playerDoesntHave[pid] = converted
+      }
+      if (saved.autoFillEnabled !== undefined) {
+        autoFillEnabled.value = saved.autoFillEnabled
       }
       restoring = false
     }
@@ -159,13 +180,15 @@ function emitNotesChanged() {
   emit('notes-changed', {
     notes: { ...notes },
     shownBy: { ...shownByMap },
-    playerDoesntHave: doesntHaveCopy
+    playerDoesntHave: doesntHaveCopy,
+    autoFillEnabled: autoFillEnabled.value
   })
 }
 
 // Watch for any notes changes and emit
 watch(notes, () => emitNotesChanged(), { deep: true })
 watch(playerDoesntHave, () => emitNotesChanged(), { deep: true })
+watch(autoFillEnabled, () => emitNotesChanged())
 
 function noteMark(card) {
   const state = notes[card] ?? ''
@@ -195,6 +218,33 @@ function cycleNote(card) {
   notes[card] = next
 }
 
+function playerMarkDisplay(playerId, card) {
+  return playerDoesntHave[playerId]?.[card] || ''
+}
+
+function playerCellClass(playerId, card) {
+  const mark = playerDoesntHave[playerId]?.[card] || ''
+  return {
+    'mark-no': mark === '\u2717',
+    'mark-yes': mark === '\u2713',
+    'mark-maybe': mark === '?'
+  }
+}
+
+function cyclePlayerMark(playerId, card) {
+  if (!playerDoesntHave[playerId]) {
+    playerDoesntHave[playerId] = {}
+  }
+  const current = playerDoesntHave[playerId][card] || ''
+  const idx = PLAYER_MARK_CYCLE.indexOf(current)
+  const next = PLAYER_MARK_CYCLE[(idx + 1) % PLAYER_MARK_CYCLE.length]
+  if (next) {
+    playerDoesntHave[playerId][card] = next
+  } else {
+    delete playerDoesntHave[playerId][card]
+  }
+}
+
 // Expose for parent to programmatically mark cards
 function markCard(card, state, shownBy) {
   if (notes[card] !== 'have') {
@@ -220,11 +270,15 @@ function getCardsShownBy(playerName) {
 
 // Mark that a player doesn't have specific cards (from suggestion tracking)
 function markPlayerDoesntHaveCards(playerId, cards) {
+  if (!autoFillEnabled.value) return
   if (!playerDoesntHave[playerId]) {
     playerDoesntHave[playerId] = {}
   }
   for (const card of cards) {
-    playerDoesntHave[playerId][card] = true
+    // Only auto-fill if not already manually marked
+    if (!playerDoesntHave[playerId][card]) {
+      playerDoesntHave[playerId][card] = '\u2717'
+    }
   }
 }
 
@@ -450,8 +504,46 @@ h4 {
   color: var(--text-faint);
 }
 
-.player-col-cell.doesnt-have {
+.player-col-cell:hover {
+  background: var(--bg-hover);
+  border-radius: 2px;
+}
+
+.player-col-cell.mark-no {
   color: var(--error);
   opacity: 0.7;
+}
+
+.player-col-cell.mark-yes {
+  color: var(--success);
+  opacity: 0.8;
+}
+
+.player-col-cell.mark-maybe {
+  color: var(--accent);
+  opacity: 0.8;
+}
+
+/* Auto-fill toggle */
+.autofill-row {
+  padding: 0.2rem 0.3rem;
+  margin-bottom: 0.2rem;
+}
+
+.autofill-label {
+  display: flex;
+  align-items: center;
+  gap: 0.3rem;
+  font-size: 0.65rem;
+  color: var(--text-secondary);
+  cursor: pointer;
+  user-select: none;
+}
+
+.autofill-checkbox {
+  width: 12px;
+  height: 12px;
+  cursor: pointer;
+  accent-color: var(--accent);
 }
 </style>


### PR DESCRIPTION
## Summary
Enhanced the Detective Notes component to support multi-state player marks (no/yes/maybe) with click-to-cycle functionality, and added a toggle to control auto-filling of player marks from suggestion tracking.

## Key Changes
- **Player mark cycling**: Changed player column cells from display-only to interactive, allowing users to cycle through four states: empty, ✗ (doesn't have), ✓ (has), and ? (maybe)
- **Auto-fill toggle**: Added a checkbox to enable/disable automatic population of player marks from suggestion tracking
- **Enhanced data model**: Updated `playerDoesntHave` to store mark symbols ('✗', '✓', '?') instead of just boolean values, with backward compatibility for existing saved data
- **Visual improvements**: Added hover effects and distinct styling for each mark type (error red for ✗, success green for ✓, accent color for ?)
- **State persistence**: Auto-fill preference is now saved and restored with other detective notes

## Implementation Details
- Introduced `PLAYER_MARK_CYCLE` constant to define the cycling sequence
- Added helper functions: `playerMarkDisplay()`, `playerCellClass()`, and `cyclePlayerMark()` for cleaner mark handling
- Updated `markPlayerDoesntHaveCards()` to respect the auto-fill toggle and avoid overwriting manually set marks
- Backward compatibility: Converts legacy boolean `true` values to '✗' symbol during restoration
- All player mark changes are emitted and persisted alongside existing notes data

https://claude.ai/code/session_019ifkt6k3gXJjAdAhf8nKa4