### PR TITLE
Add comprehensive Storybook tests and fix board layout for laptop screens

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,7 +22,9 @@ jobs:
         with:
           node-version: "20"
       - run: npm install
+      - run: npx playwright install --with-deps chromium
       - run: npm run build
+      - run: npm test
 
   backend:
     name: Backend Tests

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -8,6 +8,8 @@
     "type-check": "vue-tsc --noEmit",
     "format": "prettier --write \"src/**/*.{js,ts,jsx,tsx,mjs,cjs,vue}\"",
     "format:check": "prettier --check \"src/**/*.{js,ts,jsx,tsx,mjs,cjs,vue}\"",
+    "test": "vitest run --config vitest.config.ts",
+    "test:watch": "vitest watch --config vitest.config.ts",
     "storybook": "storybook dev -p 6006",
     "build-storybook": "storybook build"
   },

--- a/frontend/src/components/clue/BoardMap.stories.ts
+++ b/frontend/src/components/clue/BoardMap.stories.ts
@@ -1,0 +1,223 @@
+import type { Meta, StoryObj } from '@storybook/vue3-vite'
+import BoardMap from './BoardMap.vue'
+
+// ── Shared test data ──
+
+const players = [
+  { id: 'p1', name: 'Alice', character: 'Miss Scarlett', type: 'human', active: true },
+  { id: 'p2', name: 'Bob', character: 'Colonel Mustard', type: 'human', active: true },
+  { id: 'p3', name: 'Agent-1', character: 'Mrs. White', type: 'agent', active: true },
+  { id: 'p4', name: 'Agent-2', character: 'Reverend Green', type: 'agent', active: true },
+  { id: 'p5', name: 'Diana', character: 'Mrs. Peacock', type: 'human', active: true },
+  { id: 'p6', name: 'GPT-4', character: 'Professor Plum', type: 'llm_agent', active: true }
+]
+
+const startPositions: Record<string, [number, number]> = {
+  p1: [0, 16],
+  p2: [7, 23],
+  p3: [24, 14],
+  p4: [24, 9],
+  p5: [5, 0],
+  p6: [18, 0]
+}
+
+const midGamePositions: Record<string, [number, number]> = {
+  p1: [2, 3],   // Study
+  p2: [8, 10],  // hallway
+  p3: [14, 3],  // Billiard Room
+  p4: [21, 10], // Ballroom
+  p5: [10, 19], // Dining Room
+  p6: [2, 19]   // Lounge
+}
+
+const baseState = {
+  game_id: 'CLUE-4821',
+  status: 'playing' as const,
+  players,
+  whose_turn: 'p1',
+  turn_number: 1,
+  current_room: {} as Record<string, string>,
+  player_positions: startPositions,
+  suggestions_this_turn: [],
+  winner: null,
+  dice_rolled: false,
+  moved: false,
+  last_roll: null,
+  pending_show_card: null,
+  was_moved_by_suggestion: {},
+  weapon_positions: {
+    Candlestick: 'Kitchen',
+    Knife: 'Study',
+    'Lead Pipe': 'Library',
+    Revolver: 'Ballroom',
+    Rope: 'Conservatory',
+    Wrench: 'Dining Room'
+  },
+  agent_trace_enabled: false
+}
+
+// ── Meta ──
+
+const meta: Meta<typeof BoardMap> = {
+  title: 'Clue/BoardMap',
+  component: BoardMap,
+  parameters: {
+    layout: 'centered'
+  },
+  argTypes: {
+    gameState: { control: 'object' },
+    playerId: { control: 'text' },
+    selectable: { control: 'boolean' },
+    reachableRooms: { control: 'object' },
+    reachablePositions: { control: 'object' }
+  },
+  args: {
+    gameState: baseState,
+    playerId: 'p1',
+    selectedRoom: '',
+    selectable: false,
+    reachableRooms: [],
+    reachablePositions: []
+  }
+}
+
+export default meta
+type Story = StoryObj<typeof BoardMap>
+
+// ═══════════════════════════════════════════════════════════════════
+// Board at different container sizes
+// ═══════════════════════════════════════════════════════════════════
+
+/** Default: board at natural size */
+export const Default: Story = {}
+
+/** Small container: 400px — simulates tight sidebar or small screen */
+export const Small400px: Story = {
+  decorators: [
+    () => ({
+      template: '<div style="width: 400px;"><story /></div>'
+    })
+  ]
+}
+
+/** Medium container: 550px — typical laptop board column */
+export const Medium550px: Story = {
+  decorators: [
+    () => ({
+      template: '<div style="width: 550px;"><story /></div>'
+    })
+  ]
+}
+
+/** Large container: 690px — max width on desktop */
+export const Large690px: Story = {
+  decorators: [
+    () => ({
+      template: '<div style="width: 690px;"><story /></div>'
+    })
+  ]
+}
+
+// ═══════════════════════════════════════════════════════════════════
+// Game state variants
+// ═══════════════════════════════════════════════════════════════════
+
+/** All players at starting positions */
+export const StartPositions: Story = {
+  args: {
+    gameState: baseState
+  }
+}
+
+/** Mid-game: players scattered in rooms and hallways */
+export const MidGame: Story = {
+  args: {
+    gameState: {
+      ...baseState,
+      turn_number: 12,
+      player_positions: midGamePositions,
+      current_room: {
+        p1: 'Study',
+        p3: 'Billiard Room',
+        p4: 'Ballroom',
+        p5: 'Dining Room',
+        p6: 'Lounge'
+      }
+    }
+  }
+}
+
+/** Multiple players in same room — tests token stacking */
+export const CrowdedRoom: Story = {
+  args: {
+    gameState: {
+      ...baseState,
+      player_positions: {
+        p1: [2, 3],   // Study
+        p2: [2, 4],   // Study
+        p3: [3, 3],   // Study
+        p4: [3, 4],   // Study
+        p5: [10, 19], // Dining Room
+        p6: [10, 20]  // Dining Room
+      },
+      current_room: {
+        p1: 'Study',
+        p2: 'Study',
+        p3: 'Study',
+        p4: 'Study',
+        p5: 'Dining Room',
+        p6: 'Dining Room'
+      }
+    }
+  }
+}
+
+/** Interactive: rooms are selectable, some reachable */
+export const SelectableRooms: Story = {
+  args: {
+    gameState: {
+      ...baseState,
+      player_positions: midGamePositions,
+      current_room: { p1: 'Study' },
+      dice_rolled: true,
+      last_roll: [5, 3]
+    },
+    selectable: true,
+    reachableRooms: ['Hall', 'Kitchen', 'Library']
+  }
+}
+
+/** Weapons displayed in rooms */
+export const WithWeapons: Story = {
+  args: {
+    gameState: {
+      ...baseState,
+      player_positions: midGamePositions,
+      current_room: {
+        p1: 'Study',
+        p3: 'Billiard Room'
+      },
+      weapon_positions: {
+        Candlestick: 'Kitchen',
+        Knife: 'Study',
+        'Lead Pipe': 'Library',
+        Revolver: 'Ballroom',
+        Rope: 'Conservatory',
+        Wrench: 'Dining Room'
+      }
+    }
+  }
+}
+
+/** Game over state */
+export const GameOver: Story = {
+  args: {
+    gameState: {
+      ...baseState,
+      status: 'finished',
+      winner: 'p1',
+      player_positions: midGamePositions,
+      current_room: { p1: 'Study' }
+    }
+  }
+}

--- a/frontend/src/components/clue/BoardMap.vue
+++ b/frontend/src/components/clue/BoardMap.vue
@@ -646,7 +646,7 @@ function tokenStyle(token) {
   position: relative;
   box-sizing: border-box;
   width: 100%;
-  max-width: 690px;
+  max-width: min(690px, calc(100vh - 180px));
   margin: 0 auto;
   aspect-ratio: 24 / 25;
   background: transparent;

--- a/frontend/src/components/clue/GameBoard.stories.ts
+++ b/frontend/src/components/clue/GameBoard.stories.ts
@@ -1,0 +1,474 @@
+import type { Meta, StoryObj } from '@storybook/vue3-vite'
+import GameBoard from './GameBoard.vue'
+
+// ── Shared test data ──
+
+const players = [
+  { id: 'p1', name: 'Alice', character: 'Miss Scarlett', type: 'human', active: true },
+  { id: 'p2', name: 'Bob', character: 'Colonel Mustard', type: 'human', active: true },
+  { id: 'p3', name: 'Agent-1', character: 'Mrs. White', type: 'agent', active: true },
+  { id: 'p4', name: 'Agent-2', character: 'Reverend Green', type: 'agent', active: true },
+  { id: 'p5', name: 'Diana', character: 'Mrs. Peacock', type: 'human', active: true },
+  { id: 'p6', name: 'GPT-4', character: 'Professor Plum', type: 'llm_agent', active: true }
+]
+
+const playerPositions: Record<string, [number, number]> = {
+  p1: [0, 16],  // Scarlett start
+  p2: [7, 23],  // Mustard start
+  p3: [24, 14], // White start
+  p4: [24, 9],  // Green start
+  p5: [5, 0],   // Peacock start (using Plum's start pos)
+  p6: [18, 0]   // Plum start (using Peacock's start pos)
+}
+
+const midGamePositions: Record<string, [number, number]> = {
+  p1: [2, 3],   // Study
+  p2: [8, 10],  // center area
+  p3: [14, 3],  // Billiard Room
+  p4: [21, 10], // Ballroom
+  p5: [10, 19], // Dining Room
+  p6: [2, 19]   // Lounge
+}
+
+const baseGameState = {
+  game_id: 'CLUE-4821',
+  status: 'playing' as const,
+  players,
+  whose_turn: 'p1',
+  turn_number: 1,
+  current_room: {} as Record<string, string>,
+  player_positions: playerPositions,
+  suggestions_this_turn: [],
+  winner: null,
+  dice_rolled: false,
+  moved: false,
+  last_roll: null,
+  pending_show_card: null,
+  was_moved_by_suggestion: {},
+  weapon_positions: {
+    Candlestick: 'Kitchen',
+    Knife: 'Study',
+    'Lead Pipe': 'Library',
+    Revolver: 'Ballroom',
+    Rope: 'Conservatory',
+    Wrench: 'Dining Room'
+  },
+  agent_trace_enabled: false
+}
+
+const midGameState = {
+  ...baseGameState,
+  turn_number: 12,
+  player_positions: midGamePositions,
+  current_room: {
+    p1: 'Study',
+    p3: 'Billiard Room',
+    p4: 'Ballroom',
+    p5: 'Dining Room',
+    p6: 'Lounge'
+  },
+  dice_rolled: true,
+  moved: true,
+  last_roll: [4, 3],
+  suggestions_this_turn: [
+    {
+      suspect: 'Colonel Mustard',
+      weapon: 'Knife',
+      room: 'Study',
+      suggested_by: 'p1',
+      pending_show_by: null
+    }
+  ]
+}
+
+const now = new Date()
+function ts(secondsAgo: number) {
+  return new Date(now.getTime() - secondsAgo * 1000).toISOString()
+}
+
+const chatMessages = [
+  { type: 'chat_message', player_id: null, text: 'Alice rolled a 6 and moved to the Study.', timestamp: ts(320) },
+  { type: 'chat_message', player_id: null, text: 'Alice suggests it was Colonel Mustard with the Knife in the Study.', timestamp: ts(310) },
+  { type: 'chat_message', player_id: null, text: 'Bob showed a card to Alice.', timestamp: ts(305) },
+  { type: 'chat_message', player_id: null, text: 'Bob rolled a 4 and moved to the Library.', timestamp: ts(240) },
+  { type: 'chat_message', player_id: null, text: 'Bob suggests it was Mrs. White with the Revolver in the Library.', timestamp: ts(230) },
+  { type: 'chat_message', player_id: null, text: 'No one could disprove the suggestion.', timestamp: ts(228) },
+  { type: 'chat_message', player_id: 'p1', text: 'Alice: I think I know who did it!', timestamp: ts(180) },
+  { type: 'chat_message', player_id: null, text: 'Agent-1 rolled a 3 and used the secret passage to the Study.', timestamp: ts(120) },
+  { type: 'chat_message', player_id: null, text: 'Agent-1 suggests it was Professor Plum with the Rope in the Study.', timestamp: ts(115) },
+  { type: 'chat_message', player_id: null, text: 'Diana showed a card to Agent-1.', timestamp: ts(110) },
+  { type: 'chat_message', player_id: 'p2', text: 'Bob: Hmm, interesting move there.', timestamp: ts(80) },
+  { type: 'chat_message', player_id: null, text: 'Diana rolled a 5 and moved to the Dining Room.', timestamp: ts(60) },
+  { type: 'chat_message', player_id: null, text: 'GPT-4 rolled a 7 and moved to the Lounge.', timestamp: ts(30) }
+]
+
+const yourCards = ['Miss Scarlett', 'Knife', 'Library']
+
+// ── Meta ──
+
+const meta: Meta<typeof GameBoard> = {
+  title: 'Clue/GameBoard',
+  component: GameBoard,
+  parameters: {
+    layout: 'fullscreen'
+  },
+  argTypes: {
+    gameId: { control: 'text' },
+    playerId: { control: 'text' },
+    gameState: { control: 'object' },
+    yourCards: { control: 'object' },
+    availableActions: { control: 'object' },
+    chatMessages: { control: 'object' },
+    isObserver: { control: 'boolean' },
+    reachableRooms: { control: 'object' },
+    savedNotes: { control: 'object' }
+  },
+  args: {
+    gameId: 'CLUE-4821',
+    playerId: 'p1',
+    gameState: midGameState,
+    yourCards,
+    availableActions: ['suggest', 'accuse', 'end_turn'],
+    chatMessages,
+    isObserver: false,
+    reachableRooms: [],
+    reachablePositions: [],
+    savedNotes: null,
+    showCardRequest: undefined,
+    cardShown: undefined,
+    autoEndTimer: undefined,
+    agentDebugData: {},
+    observerPlayerState: undefined,
+    suggestionTracking: null
+  }
+}
+
+export default meta
+type Story = StoryObj<typeof GameBoard>
+
+// ═══════════════════════════════════════════════════════════════════
+// Size class stories — test the layout at specific viewport widths
+// ═══════════════════════════════════════════════════════════════════
+
+/** Desktop: 1920×1080 — typical external monitor */
+export const Desktop1080p: Story = {
+  parameters: {
+    viewport: { defaultViewport: { width: 1920, height: 1080 } }
+  }
+}
+
+/** Laptop: 1440×900 — common MacBook / Windows laptop */
+export const Laptop1440: Story = {
+  parameters: {
+    viewport: { defaultViewport: { width: 1440, height: 900 } }
+  }
+}
+
+/** Small laptop: 1366×768 — most common laptop resolution worldwide */
+export const Laptop1366: Story = {
+  parameters: {
+    viewport: { defaultViewport: { width: 1366, height: 768 } }
+  }
+}
+
+/** Tablet landscape: 1024×768 — iPad classic */
+export const TabletLandscape: Story = {
+  parameters: {
+    viewport: { defaultViewport: { width: 1024, height: 768 } }
+  }
+}
+
+/** Tablet portrait: 768×1024 — iPad portrait (stacked layout) */
+export const TabletPortrait: Story = {
+  parameters: {
+    viewport: { defaultViewport: { width: 768, height: 1024 } }
+  }
+}
+
+/** Mobile: 390×844 — iPhone 14 / modern phone */
+export const Mobile: Story = {
+  parameters: {
+    viewport: { defaultViewport: { width: 390, height: 844 } }
+  }
+}
+
+/** Small mobile: 320×568 — iPhone SE / compact phone */
+export const MobileSmall: Story = {
+  parameters: {
+    viewport: { defaultViewport: { width: 320, height: 568 } }
+  }
+}
+
+// ═══════════════════════════════════════════════════════════════════
+// Game state stories
+// ═══════════════════════════════════════════════════════════════════
+
+/** Early game — dice not yet rolled, all players at starting positions */
+export const EarlyGame: Story = {
+  args: {
+    gameState: {
+      ...baseGameState,
+      turn_number: 1,
+      dice_rolled: false,
+      moved: false,
+      last_roll: null
+    },
+    yourCards,
+    availableActions: ['roll']
+  }
+}
+
+/** Player's turn — dice rolled, must choose a room to move to */
+export const RolledDice: Story = {
+  args: {
+    gameState: {
+      ...midGameState,
+      dice_rolled: true,
+      moved: false,
+      last_roll: [5, 3]
+    },
+    availableActions: ['move'],
+    reachableRooms: ['Hall', 'Kitchen', 'Library']
+  }
+}
+
+/** Player can make a suggestion after moving into a room */
+export const CanSuggest: Story = {
+  args: {
+    gameState: {
+      ...midGameState,
+      dice_rolled: true,
+      moved: true,
+      last_roll: [4, 2]
+    },
+    availableActions: ['suggest', 'accuse', 'end_turn']
+  }
+}
+
+/** Player has been shown a card after making a suggestion */
+export const CardShown: Story = {
+  args: {
+    gameState: midGameState,
+    availableActions: ['accuse', 'end_turn'],
+    cardShown: {
+      card: 'Colonel Mustard',
+      by: 'p2',
+      suspect: 'Colonel Mustard',
+      weapon: 'Knife',
+      room: 'Study'
+    }
+  }
+}
+
+/** Player must choose which card to show to the suggesting player */
+export const MustShowCard: Story = {
+  args: {
+    gameState: {
+      ...midGameState,
+      whose_turn: 'p2'
+    },
+    availableActions: ['show_card'],
+    showCardRequest: {
+      suggestingPlayerId: 'p2',
+      suspect: 'Miss Scarlett',
+      weapon: 'Knife',
+      room: 'Library',
+      matching_cards: ['Miss Scarlett', 'Knife', 'Library']
+    }
+  }
+}
+
+/** Waiting for another player's turn */
+export const WaitingForTurn: Story = {
+  args: {
+    gameState: {
+      ...midGameState,
+      whose_turn: 'p2'
+    },
+    availableActions: []
+  }
+}
+
+/** Observer view — watching without participating */
+export const Observer: Story = {
+  args: {
+    playerId: 'observer-xyz',
+    isObserver: true,
+    gameState: midGameState,
+    yourCards: [],
+    availableActions: []
+  }
+}
+
+/** Game over — winner declared with solution revealed */
+export const GameOver: Story = {
+  args: {
+    gameState: {
+      ...midGameState,
+      status: 'finished',
+      winner: 'p1',
+      solution: {
+        suspect: 'Professor Plum',
+        weapon: 'Rope',
+        room: 'Conservatory'
+      }
+    },
+    availableActions: [],
+    chatMessages: [
+      ...chatMessages,
+      { type: 'chat_message', player_id: null, text: 'Alice accuses Professor Plum with the Rope in the Conservatory!', timestamp: ts(10) },
+      { type: 'chat_message', player_id: null, text: 'Alice is correct! The case is solved!', timestamp: ts(5) }
+    ]
+  }
+}
+
+/** Player eliminated after a wrong accusation */
+export const Eliminated: Story = {
+  args: {
+    gameState: {
+      ...midGameState,
+      players: players.map((p) =>
+        p.id === 'p1' ? { ...p, active: false } : p
+      ),
+      whose_turn: 'p2'
+    },
+    availableActions: []
+  }
+}
+
+/** With detective notes partially filled in */
+export const WithNotes: Story = {
+  args: {
+    gameState: midGameState,
+    availableActions: ['suggest', 'accuse', 'end_turn'],
+    savedNotes: {
+      notes: {
+        'Miss Scarlett': 'have',
+        'Colonel Mustard': 'no',
+        'Mrs. White': 'maybe',
+        'Reverend Green': 'no',
+        'Mrs. Peacock': 'seen',
+        'Professor Plum': '',
+        Knife: 'have',
+        Candlestick: 'no',
+        'Lead Pipe': 'seen',
+        Revolver: 'no',
+        Rope: '',
+        Wrench: 'no',
+        Library: 'have',
+        Kitchen: 'no',
+        Ballroom: '',
+        Conservatory: 'no',
+        'Billiard Room': 'no',
+        Study: 'no',
+        Hall: 'no',
+        Lounge: 'no',
+        'Dining Room': 'no'
+      },
+      shownBy: {
+        'Mrs. Peacock': 'Bob',
+        'Lead Pipe': 'Agent-1'
+      }
+    }
+  }
+}
+
+/** Six players with wanderer — full lobby, dense board */
+export const FullGame: Story = {
+  args: {
+    gameState: {
+      ...midGameState,
+      players: [
+        ...players,
+        { id: 'w1', name: 'Ghost', character: 'Mrs. White', type: 'wanderer', active: true }
+      ],
+      player_positions: {
+        ...midGamePositions,
+        w1: [15, 15]
+      }
+    }
+  }
+}
+
+/** Auto-end timer counting down */
+export const AutoEndTimer: Story = {
+  args: {
+    gameState: {
+      ...midGameState,
+      whose_turn: 'p1'
+    },
+    availableActions: ['end_turn'],
+    autoEndTimer: {
+      playerId: 'p1',
+      seconds: 15,
+      startedAt: Date.now() - 5000
+    }
+  }
+}
+
+// ═══════════════════════════════════════════════════════════════════
+// Layout-specific: laptop height constraint tests
+// ═══════════════════════════════════════════════════════════════════
+
+/** Laptop 1440×900 with notes open — tests the height constraint fix */
+export const Laptop1440WithNotes: Story = {
+  parameters: {
+    viewport: { defaultViewport: { width: 1440, height: 900 } }
+  },
+  args: {
+    gameState: midGameState,
+    availableActions: ['suggest', 'accuse', 'end_turn'],
+    savedNotes: {
+      notes: {
+        'Miss Scarlett': 'have',
+        'Colonel Mustard': 'no',
+        'Mrs. White': 'maybe',
+        'Reverend Green': 'no',
+        'Mrs. Peacock': 'seen',
+        'Professor Plum': '',
+        Knife: 'have',
+        Candlestick: 'no',
+        'Lead Pipe': 'seen',
+        Revolver: 'no',
+        Rope: '',
+        Wrench: 'no',
+        Library: 'have',
+        Kitchen: 'no',
+        Ballroom: '',
+        Conservatory: 'no',
+        'Billiard Room': 'no',
+        Study: 'no',
+        Hall: 'no',
+        Lounge: 'no',
+        'Dining Room': 'no'
+      },
+      shownBy: { 'Mrs. Peacock': 'Bob' }
+    }
+  }
+}
+
+/** 1366×768 with full game state — most constrained common laptop */
+export const Laptop1366FullState: Story = {
+  parameters: {
+    viewport: { defaultViewport: { width: 1366, height: 768 } }
+  },
+  args: {
+    gameState: {
+      ...midGameState,
+      last_roll: [5, 3],
+      dice_rolled: true,
+      moved: true
+    },
+    availableActions: ['suggest', 'accuse', 'end_turn'],
+    chatMessages,
+    savedNotes: {
+      notes: {
+        'Miss Scarlett': 'have',
+        'Colonel Mustard': 'no',
+        Knife: 'have',
+        Library: 'have'
+      },
+      shownBy: {}
+    }
+  }
+}

--- a/frontend/src/components/clue/GameBoard.vue
+++ b/frontend/src/components/clue/GameBoard.vue
@@ -374,16 +374,16 @@
             }" :players="gameState?.players" :game-state="gameState" />
           </section>
         </template>
-      </div>
 
-      <!-- Chat (at bottom of responsive stack) -->
-      <section class="sidebar-panel chat-panel-wrapper">
-        <ChatPanel
-          :messages="chatMessages"
-          :players="gameState?.players"
-          @send-message="$emit('send-chat', $event)"
-        />
-      </section>
+        <!-- Chat (in sidebar) -->
+        <section class="sidebar-panel chat-panel-wrapper">
+          <ChatPanel
+            :messages="chatMessages"
+            :players="gameState?.players"
+            @send-message="$emit('send-chat', $event)"
+          />
+        </section>
+      </div>
     </div>
     <Teleport to="body">
       <div v-if="cardShown && !cardShownDismissedOnce" class="card-shown-overlay" @click="dismissCardShownOverlay">
@@ -966,6 +966,7 @@ watch(
   gap: 0.75rem;
   min-height: 400px;
   align-items: start;
+  max-height: calc(100vh - 70px);
 }
 
 /* Board column */
@@ -973,6 +974,8 @@ watch(
   display: flex;
   flex-direction: column;
   gap: 0.5rem;
+  max-height: calc(100vh - 70px);
+  overflow-y: auto;
 }
 
 /* Player legend */
@@ -1114,6 +1117,8 @@ watch(
   display: flex;
   flex-direction: column;
   gap: 0.6rem;
+  max-height: calc(100vh - 70px);
+  overflow-y: auto;
 }
 
 .sidebar-panel {
@@ -1616,8 +1621,7 @@ watch(
 
 /* Chat */
 .chat-panel-wrapper {
-  min-height: 160px;
-  grid-column: 1 / -1;
+  min-height: 200px;
 }
 
 /* Card thumbnails in hand */
@@ -2269,6 +2273,7 @@ watch(
 @media (max-width: 900px) {
   .main-layout {
     grid-template-columns: 1fr;
+    max-height: none;
   }
 
   .game-header {
@@ -2282,6 +2287,13 @@ watch(
 
   .sidebar-column {
     max-width: 100%;
+    max-height: none;
+    overflow-y: visible;
+  }
+
+  .board-column {
+    max-height: none;
+    overflow-y: visible;
   }
 }
 

--- a/frontend/vitest.config.ts
+++ b/frontend/vitest.config.ts
@@ -1,0 +1,28 @@
+/// <reference types="vitest/config" />
+import path from 'node:path'
+import { fileURLToPath } from 'node:url'
+import { defineConfig } from 'vitest/config'
+import vue from '@vitejs/plugin-vue'
+import { storybookTest } from '@storybook/addon-vitest/vitest-plugin'
+import { playwright } from '@vitest/browser-playwright'
+
+const dirname = typeof __dirname !== 'undefined' ? __dirname : path.dirname(fileURLToPath(import.meta.url))
+
+export default defineConfig({
+  plugins: [
+    vue(),
+    storybookTest({
+      configDir: path.join(dirname, '.storybook')
+    })
+  ],
+  test: {
+    name: 'storybook',
+    browser: {
+      enabled: true,
+      headless: true,
+      provider: playwright({}),
+      instances: [{ browser: 'chromium' }]
+    },
+    setupFiles: ['.storybook/vitest.setup.ts']
+  }
+})


### PR DESCRIPTION
- Add GameBoard.stories.ts with 18 stories covering viewport sizes
  (1920x1080, 1440x900, 1366x768, tablet, mobile) and game states
  (early game, rolled dice, suggestions, card shown, must show card,
  observer, game over, eliminated, with notes, auto-end timer)
- Add BoardMap.stories.ts with stories for different container sizes
  and game states (start positions, mid-game, crowded rooms, selectable
  rooms, weapons)
- Move chat panel from full-width bottom into the sidebar column,
  reducing vertical space usage significantly on laptop screens
- Add viewport-height constraints on board, sidebar, and board column
  so the layout fits within 100vh on laptop screens (1440x900, 1366x768)
- Board max-width now uses min(690px, calc(100vh - 180px)) to scale
  down on shorter viewports
- Remove height constraints on mobile (<900px) where scrolling is natural

https://claude.ai/code/session_017FJ6RHjWSk5gfAin2k9oVv