### PR TITLE
Use last name initial in detective notes player columns

### DIFF
--- a/frontend/src/components/clue/DetectiveNotes.vue
+++ b/frontend/src/components/clue/DetectiveNotes.vue
@@ -141,7 +141,9 @@ const trackedPlayers = computed(() =>
 )
 
 function playerInitial(p) {
-  return (p.name || p.character || '?')[0].toUpperCase()
+  const name = p.name || p.character || '?'
+  const parts = name.trim().split(/\s+/)
+  return parts[parts.length - 1][0].toUpperCase()
 }
 
 // Restore saved notes when they arrive (e.g. on rejoin)


### PR DESCRIPTION
Change playerInitial() to split the player name and use the first
letter of the last word, instead of the first letter of the full name.

https://claude.ai/code/session_012gNhaRaKMeUposXXFoHirN