### PR TITLE
Hide 'wandering' label on mobile in player list

### DIFF
--- a/frontend/src/components/clue/GameBoard.vue
+++ b/frontend/src/components/clue/GameBoard.vue
@@ -1083,6 +1083,12 @@ watch(
   font-style: italic;
 }
 
+@media (max-width: 600px) {
+  .legend-wanderer-label {
+    display: none;
+  }
+}
+
 /* Shown cards popup */
 .shown-cards-popup {
   position: absolute;


### PR DESCRIPTION
Add media query to hide .legend-wanderer-label at 600px and below.

https://claude.ai/code/session_01DpLQmy67P72mxLcxrsGZ6Y