### PR TITLE
Move auto-fill checkbox to Detective Notes header

### DIFF
--- a/frontend/src/components/clue/DetectiveNotes.vue
+++ b/frontend/src/components/clue/DetectiveNotes.vue
@@ -1,12 +1,14 @@
 <template>
   <div class="detective-notes">
-    <h3 class="panel-header">
-      Detective Notes
+    <div class="panel-header-row">
+      <h3 class="panel-header">
+        Detective Notes
+      </h3>
       <label v-if="trackedPlayers.length" class="autofill-label" @click.stop>
         <input type="checkbox" v-model="autoFillEnabled" class="autofill-checkbox" />
         Auto-fill
       </label>
-    </h3>
+    </div>
     <div v-if="trackedPlayers.length" class="player-columns-legend">
       <div class="legend-spacer"></div>
       <div v-for="p in trackedPlayers" :key="p.id" class="player-col-header"
@@ -543,7 +545,7 @@ h4 {
 }
 
 /* Make header a flex row so the checkbox sits on the right */
-.panel-header {
+.panel-header-row {
   display: flex;
   align-items: center;
   justify-content: space-between;

--- a/frontend/src/components/clue/DetectiveNotes.vue
+++ b/frontend/src/components/clue/DetectiveNotes.vue
@@ -1,14 +1,12 @@
 <template>
   <div class="detective-notes">
-    <h3 class="panel-header">Detective Notes</h3>
-
-    <!-- Auto-fill toggle + Player column legend -->
-    <div v-if="trackedPlayers.length" class="autofill-row">
-      <label class="autofill-label">
+    <h3 class="panel-header">
+      Detective Notes
+      <label v-if="trackedPlayers.length" class="autofill-label" @click.stop>
         <input type="checkbox" v-model="autoFillEnabled" class="autofill-checkbox" />
-        Auto-fill from suggestions
+        Auto-fill
       </label>
-    </div>
+    </h3>
     <div v-if="trackedPlayers.length" class="player-columns-legend">
       <div class="legend-spacer"></div>
       <div v-for="p in trackedPlayers" :key="p.id" class="player-col-header"
@@ -544,20 +542,25 @@ h4 {
   opacity: 0.8;
 }
 
-/* Auto-fill toggle */
-.autofill-row {
-  padding: 0.2rem 0.3rem;
-  margin-bottom: 0.2rem;
+/* Make header a flex row so the checkbox sits on the right */
+.panel-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
 }
 
+/* Auto-fill toggle in header */
 .autofill-label {
   display: flex;
   align-items: center;
-  gap: 0.3rem;
-  font-size: 0.65rem;
+  gap: 0.25rem;
+  font-size: 0.6rem;
+  font-weight: 400;
   color: var(--text-secondary);
   cursor: pointer;
   user-select: none;
+  text-transform: none;
+  letter-spacing: 0;
 }
 
 .autofill-checkbox {


### PR DESCRIPTION
Relocates the "Auto-fill from suggestions" checkbox from its own row below the header into the panel header itself, saving vertical space.

https://claude.ai/code/session_01RNHZ5Znb4Dioii1xXRvkGh