### PR TITLE
Improve shown cards popup positioning and auto-fill detective notes

### DIFF
--- a/frontend/src/components/clue/DetectiveNotes.vue
+++ b/frontend/src/components/clue/DetectiveNotes.vue
@@ -269,7 +269,19 @@ function cyclePlayerMark(playerId, card) {
 function markCard(card, state, shownBy) {
   if (notes[card] !== 'have') {
     notes[card] = state
-    if (shownBy) shownByMap[card] = shownBy
+    if (shownBy) {
+      shownByMap[card] = shownBy
+      // Auto-fill green check in player column for the showing player
+      if (autoFillEnabled.value) {
+        const showingPlayer = trackedPlayers.value.find(p => p.name === shownBy || p.character === shownBy)
+        if (showingPlayer) {
+          if (!playerMarks[showingPlayer.id]) {
+            playerMarks[showingPlayer.id] = {}
+          }
+          playerMarks[showingPlayer.id][card] = '\u2713'
+        }
+      }
+    }
   }
 }
 

--- a/frontend/src/components/clue/GameBoard.vue
+++ b/frontend/src/components/clue/GameBoard.vue
@@ -101,7 +101,9 @@
             <span v-if="p.type === 'wanderer'" class="legend-wanderer-label">wandering</span>
             <span v-else-if="gameState?.whose_turn === p.id" class="legend-turn">turn</span>
             <!-- Shown cards popup -->
-            <div v-if="shownCardsPlayerId === p.id && shownCardsForPlayer.length" class="shown-cards-popup" @click.stop>
+            <div v-if="shownCardsPlayerId === p.id && shownCardsForPlayer.length"
+              ref="shownCardsPopupRef"
+              class="shown-cards-popup" :class="{ 'popup-above': popupGoesUp }" @click.stop>
               <div class="shown-cards-title">Cards shown to you:</div>
               <div class="shown-cards-hand">
                 <div v-for="card in shownCardsForPlayer" :key="card" class="hand-card" :class="cardCategory(card)"
@@ -112,8 +114,9 @@
                 </div>
               </div>
             </div>
-            <div v-if="shownCardsPlayerId === p.id && !shownCardsForPlayer.length" class="shown-cards-popup"
-              @click.stop>
+            <div v-if="shownCardsPlayerId === p.id && !shownCardsForPlayer.length"
+              ref="shownCardsPopupRef"
+              class="shown-cards-popup" :class="{ 'popup-above': popupGoesUp }" @click.stop>
               <div class="shown-cards-title">No cards shown to you</div>
             </div>
           </div>
@@ -504,7 +507,7 @@
 </template>
 
 <script setup>
-import { ref, computed, watch, onMounted, onUnmounted } from 'vue'
+import { ref, computed, watch, nextTick, onMounted, onUnmounted } from 'vue'
 import BoardMap from './BoardMap.vue'
 import ChatPanel from './ChatPanel.vue'
 import DetectiveNotes from './DetectiveNotes.vue'
@@ -675,6 +678,8 @@ function cardCategory(card) {
 
 // Shown cards popup state
 const shownCardsPlayerId = ref(null)
+const shownCardsPopupRef = ref(null)
+const popupGoesUp = ref(false)
 const shownCardsForPlayer = computed(() => {
   if (!shownCardsPlayerId.value || !notesRef.value) return []
   const pName = playerName(shownCardsPlayerId.value)
@@ -690,7 +695,17 @@ function onLegendClick(player) {
   if (shownCardsPlayerId.value === player.id) {
     shownCardsPlayerId.value = null
   } else {
+    popupGoesUp.value = false
     shownCardsPlayerId.value = player.id
+    nextTick(() => {
+      const el = shownCardsPopupRef.value
+      if (el) {
+        const rect = el.getBoundingClientRect()
+        if (rect.bottom > window.innerHeight) {
+          popupGoesUp.value = true
+        }
+      }
+    })
   }
 }
 
@@ -1006,6 +1021,9 @@ watch(
   display: flex;
   flex-wrap: wrap;
   gap: 0.4rem;
+  overflow: visible;
+  position: relative;
+  z-index: 5;
 }
 
 .legend-item {
@@ -1119,7 +1137,13 @@ watch(
   border-radius: 4px;
   padding: 0.4rem 0.6rem;
   min-width: 140px;
+  max-width: calc(100vw - 2rem);
   box-shadow: 0 4px 12px rgba(0, 0, 0, 0.5);
+}
+
+.shown-cards-popup.popup-above {
+  top: auto;
+  bottom: 100%;
 }
 
 .shown-cards-title {


### PR DESCRIPTION
## Summary
This PR enhances the shown cards popup behavior and improves the detective notes auto-fill functionality to provide a better user experience.

## Key Changes

- **Smart popup positioning**: The shown cards popup now detects when it would overflow below the viewport and automatically repositions itself above the trigger element instead
  - Added `popupGoesUp` state to track popup direction
  - Added `shownCardsPopupRef` template reference to measure popup dimensions
  - Uses `nextTick()` to measure the popup after rendering and adjust position accordingly
  - Added CSS class `popup-above` to style the repositioned popup

- **Enhanced popup styling**: 
  - Added `max-width: calc(100vw - 2rem)` to prevent horizontal overflow
  - Added `overflow: visible`, `position: relative`, and `z-index: 5` to the legend container for proper popup layering

- **Auto-fill detective notes**: When marking a card as shown by a player, the detective notes now automatically adds a green checkmark in that player's column if auto-fill is enabled
  - Finds the showing player from tracked players list
  - Creates player marks entry if needed
  - Sets the checkmark character (`\u2713`) for the card

- **Minor refactoring**: Added `nextTick` import to support deferred DOM measurements

## Implementation Details
The popup positioning logic waits for the DOM to update before measuring the popup element's position, ensuring accurate calculations. The auto-fill feature respects the existing auto-fill toggle setting and only applies when enabled.

https://claude.ai/code/session_018abjG7mfkNB33jtwgGGqDD