### PR TITLE
Stop auto-end timer when player clicks Make Final Accusation

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -1715,6 +1715,27 @@ async def ack_card_shown(game_id: str, req: dict):
 # ---------------------------------------------------------------------------
 
 
+@app.post("/api/clue/games/{game_id}/cancel_auto_end_timer")
+async def cancel_auto_end_timer(game_id: str, req: dict):
+    """Cancel the auto-end-turn timer (e.g. when a player opens the accusation form)."""
+    player_id = req.get("player_id")
+    if not player_id:
+        raise HTTPException(status_code=400, detail="player_id required")
+    game = ClueGame(game_id, redis_client)
+    state = await game.get_state()
+    if not state or state.status != "playing":
+        return OkResponse()
+    # Only the current player can cancel their own timer
+    if state.whose_turn == player_id:
+        _cancel_auto_end_timer(game_id)
+        # Notify clients to clear the timer UI
+        await manager.broadcast(
+            game_id,
+            AutoEndTimerMessage(player_id=player_id, seconds=0),
+        )
+    return OkResponse()
+
+
 @app.put("/api/clue/games/{game_id}/notes")
 async def save_notes(game_id: str, req: SaveNotesRequest):
     game = ClueGame(game_id, redis_client)

--- a/frontend/src/App.vue
+++ b/frontend/src/App.vue
@@ -16,7 +16,8 @@
         :auto-show-card-timer="autoShowCardTimer" :reachable-rooms="reachableRooms"
         :reachable-positions="reachablePositions" :saved-notes="savedNotes" :agent-debug-data="agentDebugData"
         :observer-player-state="observerPlayerState" @action="sendAction" @send-chat="sendChat"
-        @dismiss-card-shown="onDismissCardShown" @select-player="onObserverSelectPlayer" />
+        @dismiss-card-shown="onDismissCardShown" @cancel-auto-end-timer="onCancelAutoEndTimer"
+        @select-player="onObserverSelectPlayer" />
     </template>
 
     <!-- Texas Hold'em views -->
@@ -312,10 +313,14 @@ function handleMessage(msg) {
       break
 
     case 'auto_end_timer':
-      autoEndTimer.value = {
-        playerId: msg.player_id,
-        seconds: msg.seconds,
-        startedAt: Date.now()
+      if (msg.seconds <= 0) {
+        autoEndTimer.value = null
+      } else {
+        autoEndTimer.value = {
+          playerId: msg.player_id,
+          seconds: msg.seconds,
+          startedAt: Date.now()
+        }
       }
       break
 
@@ -698,6 +703,15 @@ function onDismissCardShown() {
   cardShown.value = null
   // Tell the backend the banner is dismissed so it can start the auto-end timer
   fetch(`/api/clue/games/${gameId.value}/ack_card_shown`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ player_id: playerId.value })
+  })
+}
+
+function onCancelAutoEndTimer() {
+  autoEndTimer.value = null
+  fetch(`/api/clue/games/${gameId.value}/cancel_auto_end_timer`, {
     method: 'POST',
     headers: { 'Content-Type': 'application/json' },
     body: JSON.stringify({ player_id: playerId.value })

--- a/frontend/src/components/clue/GameBoard.vue
+++ b/frontend/src/components/clue/GameBoard.vue
@@ -272,7 +272,7 @@
 
           <!-- Accuse -->
           <div v-if="canAccuse" class="action-group accuse-group">
-            <button v-if="!showAccuseForm" class="action-btn toggle-accuse-btn" @click="showAccuseForm = true">
+            <button v-if="!showAccuseForm" class="action-btn toggle-accuse-btn" @click="showAccuseForm = true; clearCountdown(); emit('cancel-auto-end-timer')">
               Make Final Accusation...
             </button>
             <div v-if="showAccuseForm" class="accuse-form">
@@ -549,7 +549,7 @@ const props = defineProps({
   observerPlayerState: { type: Object, default: null }
 })
 
-const emit = defineEmits(['action', 'send-chat', 'dismiss-card-shown', 'select-player'])
+const emit = defineEmits(['action', 'send-chat', 'dismiss-card-shown', 'select-player', 'cancel-auto-end-timer'])
 
 const notesRef = ref(null)
 


### PR DESCRIPTION
When a player opens the accusation form, the 7-second auto-end-turn timer is now cancelled both locally (UI countdown cleared) and on the backend (async timer task cancelled). This prevents the turn from auto-ending while the player is filling out their final accusation.

https://claude.ai/code/session_01BSP6EPWXXTQMM8awDTueXa