### PR TITLE
Add light and vintage theme styling for card and game-over banners

### DIFF
--- a/frontend/src/components/clue/GameBoard.vue
+++ b/frontend/src/components/clue/GameBoard.vue
@@ -2052,6 +2052,13 @@ watch(
   animation: bannerSlideIn 0.4s cubic-bezier(0.34, 1.56, 0.64, 1);
 }
 
+[data-theme="light"] .card-shown-banner,
+[data-theme="vintage"] .card-shown-banner {
+  background: linear-gradient(145deg, var(--bg-panel-solid) 0%, var(--bg-page) 100%);
+  border-color: var(--accent-border-hover);
+  box-shadow: 0 0 40px var(--accent-glow), 0 20px 60px rgba(0, 0, 0, 0.2);
+}
+
 @keyframes bannerSlideIn {
   from {
     opacity: 0;
@@ -2077,6 +2084,13 @@ watch(
   border: 1px solid rgba(212, 168, 73, 0.2);
 }
 
+[data-theme="light"] .card-shown-banner-label,
+[data-theme="vintage"] .card-shown-banner-label {
+  color: var(--accent);
+  background: var(--accent-bg);
+  border-color: var(--accent-border);
+}
+
 .card-shown-banner-suggestion {
   font-size: 0.9rem;
   color: #c8bca8;
@@ -2093,6 +2107,18 @@ watch(
 .card-shown-banner-from {
   font-size: 1rem;
   color: #c8bca8;
+}
+
+[data-theme="light"] .card-shown-banner-suggestion,
+[data-theme="vintage"] .card-shown-banner-suggestion,
+[data-theme="light"] .card-shown-banner-from,
+[data-theme="vintage"] .card-shown-banner-from {
+  color: var(--text-secondary);
+}
+
+[data-theme="light"] .card-shown-banner-noshow,
+[data-theme="vintage"] .card-shown-banner-noshow {
+  color: var(--accent);
 }
 
 .shown-card-suggestion {
@@ -2132,9 +2158,20 @@ watch(
   letter-spacing: 0.03em;
 }
 
+[data-theme="light"] .card-shown-banner-dismiss,
+[data-theme="vintage"] .card-shown-banner-dismiss {
+  background: linear-gradient(135deg, var(--accent), var(--accent-dark));
+  color: var(--accent-text);
+}
+
 .card-shown-banner-dismiss:hover {
   transform: translateY(-1px);
   box-shadow: 0 4px 12px rgba(212, 168, 73, 0.3);
+}
+
+[data-theme="light"] .card-shown-overlay,
+[data-theme="vintage"] .card-shown-overlay {
+  background: rgba(0, 0, 0, 0.5);
 }
 
 /* ================================ */
@@ -2202,6 +2239,12 @@ watch(
   color: #d4a849;
   letter-spacing: 0.08em;
   text-shadow: 0 0 30px rgba(212, 168, 73, 0.2);
+}
+
+[data-theme="light"] .game-over-title,
+[data-theme="vintage"] .game-over-title {
+  color: var(--accent);
+  text-shadow: none;
 }
 
 .game-over-winner {
@@ -2275,6 +2318,17 @@ watch(
   cursor: pointer;
   transition: all 0.2s;
   letter-spacing: 0.04em;
+}
+
+[data-theme="light"] .game-over-dismiss,
+[data-theme="vintage"] .game-over-dismiss {
+  background: linear-gradient(135deg, var(--accent), var(--accent-dark));
+  color: var(--accent-text);
+}
+
+[data-theme="light"] .game-over-overlay,
+[data-theme="vintage"] .game-over-overlay {
+  background: rgba(0, 0, 0, 0.5);
 }
 
 .game-over-dismiss:hover {


### PR DESCRIPTION
## Summary
This PR adds theme-specific styling for card shown banners and game-over overlays to support light and vintage themes, ensuring consistent visual appearance across all theme options.

## Key Changes
- Added light and vintage theme overrides for `.card-shown-banner` with gradient backgrounds and themed border/shadow colors
- Added theme-specific styling for `.card-shown-banner-label` using accent color variables
- Added theme overrides for `.card-shown-banner-suggestion`, `.card-shown-banner-from`, and `.card-shown-banner-noshow` text colors
- Added light and vintage theme styling for `.card-shown-banner-dismiss` button with gradient backgrounds
- Added theme-specific background for `.card-shown-overlay` with semi-transparent black
- Added light and vintage theme overrides for `.game-over-title` using accent color without text-shadow
- Added theme-specific styling for `.game-over-dismiss` button with gradient backgrounds
- Added theme-specific background for `.game-over-overlay` with semi-transparent black

## Implementation Details
All theme overrides use CSS custom properties (variables) like `--accent`, `--accent-dark`, `--accent-text`, `--text-secondary`, etc., allowing for consistent theming across the application. The selectors target both `[data-theme="light"]` and `[data-theme="vintage"]` to apply the same styling rules to these two themes while preserving the existing dark theme defaults.

https://claude.ai/code/session_01RjigMA3XVQxreNdcPhkgve