### PR TITLE
Add secret passages to reachable rooms after dice roll and allow room re-entry via different doors

### DIFF
--- a/backend/app/games/clue/board.py
+++ b/backend/app/games/clue/board.py
@@ -421,6 +421,85 @@ def reachable(
     return visited
 
 
+def can_reenter_via_different_door(
+    start_room: Room,
+    dice: int,
+    squares: dict,
+    room_nodes: dict[Room, Square],
+    occupied: set[tuple[int, int]] | None = None,
+) -> bool:
+    """Check if a player in start_room can exit one door and re-enter through a different door.
+
+    For each exit door, runs a BFS from the hallway outside that door (at cost 1)
+    through hallway squares only (blocking all doors of the starting room) and
+    checks whether the hallway outside any *other* door of the same room is
+    reachable within the dice budget.
+
+    Re-entry path cost: 1 (room->exit_door->exit_hall) + hallway_path + 1 (enter_hall->enter_door->room)
+    So the hallway BFS budget is dice - 2.
+    """
+    if occupied is None:
+        occupied = set()
+
+    # Gather doors and their hallway neighbors for this room
+    door_info: list[tuple[Square, Square]] = []  # (door_sq, hallway_sq)
+    for (r, c), (room, direction) in DOORS.items():
+        if room != start_room:
+            continue
+        door_sq = squares.get((r, c))
+        dr, dc = DOOR_DIRECTIONS[direction]
+        hall_sq = squares.get((r + dr, c + dc))
+        if door_sq and hall_sq:
+            door_info.append((door_sq, hall_sq))
+
+    if len(door_info) < 2:
+        return False
+
+    hallway_budget = dice - 2
+    if hallway_budget < 0:
+        return False
+
+    # Block all doors of this room so BFS can't shortcut through it
+    blocked_doors = {(d.row, d.col) for d, _ in door_info}
+
+    entry_halls = {id(hall_sq): (door_sq, hall_sq) for door_sq, hall_sq in door_info}
+
+    for exit_idx, (exit_door, exit_hall) in enumerate(door_info):
+        if (exit_hall.row, exit_hall.col) in occupied:
+            continue
+
+        visited: dict[Square, int] = {exit_hall: 0}
+        queue: deque[tuple[Square, int]] = deque([(exit_hall, 0)])
+
+        while queue:
+            sq, dist = queue.popleft()
+            if dist > visited.get(sq, float("inf")):
+                continue
+            for nb in sq.neighbors:
+                if nb.type == SquareType.ROOM:
+                    continue
+                if (nb.row, nb.col) in blocked_doors:
+                    continue
+                if (nb.row, nb.col) in occupied:
+                    continue
+                new_dist = dist + 1
+                if new_dist > hallway_budget:
+                    continue
+                if nb in visited and visited[nb] <= new_dist:
+                    continue
+                visited[nb] = new_dist
+                queue.append((nb, new_dist))
+
+        # Check if any other door's hallway was reached
+        for enter_idx, (enter_door, enter_hall) in enumerate(door_info):
+            if enter_idx == exit_idx:
+                continue
+            if enter_hall in visited:
+                return True
+
+    return False
+
+
 def show_reachable_on_grid(
     grid: list[list[str]],
     start: Square,

--- a/backend/app/games/clue/game.py
+++ b/backend/app/games/clue/game.py
@@ -17,6 +17,7 @@ from .board import (
     SQUARES,
     Room,
     SquareType,
+    can_reenter_via_different_door,
     reachable,
     move_towards,
     find_path,
@@ -493,6 +494,22 @@ class ClueGame:
             ):
                 positions.append([sq.row, sq.col])
 
+        # Add secret passage destination room if player is in a passage room
+        current_room_name = state.current_room.get(player_id)
+        if current_room_name and current_room_name in SECRET_PASSAGE_MAP:
+            dest_room = SECRET_PASSAGE_MAP[current_room_name]
+            if dest_room not in rooms:
+                rooms.append(dest_room)
+
+        # Allow re-entering the same room via a different door
+        if current_room_name and current_room_name in ROOM_NAME_TO_ENUM:
+            current_room_enum = ROOM_NAME_TO_ENUM[current_room_name]
+            if can_reenter_via_different_door(
+                current_room_enum, dice, SQUARES, ROOM_NODES, occupied
+            ):
+                if current_room_name not in rooms:
+                    rooms.append(current_room_name)
+
         return ReachableTargets(reachable_rooms=rooms, reachable_positions=positions)
 
     async def process_action(
@@ -630,13 +647,18 @@ class ClueGame:
         if room_name and room_name not in ROOMS:
             raise ValueError(f"Invalid room: {room_name}")
 
-        # Cannot re-enter the room you are already in
         current_room_name = state.current_room.get(player_id)
-        if room_name and room_name == current_room_name:
-            raise ValueError("Cannot re-enter the room you are already in")
-
         occupied = self._get_occupied_positions(state, player_id)
         start_sq = self._get_start_square(player_id, state)
+
+        # Check re-entry: allowed only if the player can exit one door and
+        # enter through a different door within the dice roll.
+        if room_name and room_name == current_room_name:
+            current_room_enum = ROOM_NAME_TO_ENUM.get(current_room_name)
+            if not current_room_enum or not can_reenter_via_different_door(
+                current_room_enum, total, SQUARES, ROOM_NODES, occupied
+            ):
+                raise ValueError("Cannot re-enter the room you are already in")
 
         final_room: str | None = None
         final_position: list[int] | None = None
@@ -670,9 +692,33 @@ class ClueGame:
                 raise ValueError("Cannot determine current position")
 
         elif room_name:
-            target_room_enum = ROOM_NAME_TO_ENUM.get(room_name)
+            # Secret passage destination chosen after rolling: treat as passage use
+            is_secret_passage = (
+                current_room_name
+                and current_room_name in SECRET_PASSAGE_MAP
+                and room_name == SECRET_PASSAGE_MAP[current_room_name]
+            )
+            if is_secret_passage:
+                state.current_room[player_id] = room_name
+                final_room = room_name
+                center = ROOM_CENTERS.get(room_name)
+                if center:
+                    state.player_positions[player_id] = list(center)
+                    final_position = list(center)
+                dest_sq = ROOM_NODES.get(ROOM_NAME_TO_ENUM[room_name])
 
-            if start_sq and target_room_enum:
+            elif room_name == current_room_name:
+                # Re-entering same room via different door: place back in room
+                state.current_room[player_id] = room_name
+                final_room = room_name
+                center = ROOM_CENTERS.get(room_name)
+                if center:
+                    state.player_positions[player_id] = list(center)
+                    final_position = list(center)
+                dest_sq = ROOM_NODES.get(ROOM_NAME_TO_ENUM[room_name])
+
+            elif start_sq and ROOM_NAME_TO_ENUM.get(room_name):
+                target_room_enum = ROOM_NAME_TO_ENUM[room_name]
                 dest, reached = move_towards(
                     start_sq,
                     target_room_enum,

--- a/backend/tests/test_board.py
+++ b/backend/tests/test_board.py
@@ -8,6 +8,7 @@ from app.games.clue.board import (
     SquareType,
     build_grid,
     build_graph,
+    can_reenter_via_different_door,
     reachable,
     move_towards,
     START_POSITIONS,
@@ -280,3 +281,24 @@ def test_room_has_infinite_capacity(board):
         occupied={(ballroom.row, ballroom.col)},
     )
     assert ballroom in reached, "Room should be reachable regardless of occupants"
+
+
+def test_can_reenter_ballroom_via_different_door(board):
+    """Ballroom has 4 doors; re-entry via a different door should be possible."""
+    squares, room_nodes = board
+    assert can_reenter_via_different_door(Room.BALLROOM, 12, squares, room_nodes)
+
+
+def test_cannot_reenter_single_door_room(board):
+    """Rooms with only 1 door cannot be re-entered."""
+    squares, room_nodes = board
+    # Study, Lounge, Conservatory, Kitchen each have 1 door
+    for room in [Room.STUDY, Room.LOUNGE, Room.CONSERVATORY, Room.KITCHEN]:
+        assert not can_reenter_via_different_door(room, 12, squares, room_nodes)
+
+
+def test_cannot_reenter_with_low_roll(board):
+    """Even a multi-door room can't be re-entered if the roll is too low."""
+    squares, room_nodes = board
+    # Dice of 1 means budget of -1 hallway steps — impossible
+    assert not can_reenter_via_different_door(Room.BALLROOM, 1, squares, room_nodes)

--- a/backend/tests/test_game.py
+++ b/backend/tests/test_game.py
@@ -1179,19 +1179,18 @@ async def test_door_blocking_prevents_exit(game: ClueGame):
 
     state = await game._load_state()
     targets = game.get_reachable_targets(whose_turn, state, 6)
-    # No hallway positions reachable
+    # No hallway positions reachable (door is blocked)
     assert len(targets.reachable_positions) == 0
-    # Secret passage rooms should NOT appear in dice-based reachability
-    # (secret passages are used instead of rolling, not after rolling)
-    assert "Lounge" not in targets.reachable_rooms
+    # Secret passage destination should still appear as reachable
+    assert "Lounge" in targets.reachable_rooms
 
 
 @pytest.mark.asyncio
-async def test_secret_passage_rooms_excluded_from_dice_reachability(game: ClueGame):
-    """Secret passage destinations should not appear in get_reachable_targets.
+async def test_secret_passage_rooms_included_in_dice_reachability(game: ClueGame):
+    """Secret passage destinations should appear in get_reachable_targets.
 
-    Secret passages are an alternative to rolling the dice, so after rolling
-    they must not show up as reachable rooms.
+    After rolling the dice, the secret passage destination is included so
+    the player can choose it as a move target.
     """
     await _add_two_players(game)
     state = await game.start()
@@ -1207,9 +1206,9 @@ async def test_secret_passage_rooms_excluded_from_dice_reachability(game: ClueGa
 
     state = await game._load_state()
     targets = game.get_reachable_targets(whose_turn, state, 6)
-    # Kitchen (secret passage from Study) must NOT be in reachable rooms
-    assert "Kitchen" not in targets.reachable_rooms
-    # Study (current room) also excluded
+    # Kitchen (secret passage from Study) should be in reachable rooms
+    assert "Kitchen" in targets.reachable_rooms
+    # Study (current room) excluded — only 1 door, can't re-enter
     assert "Study" not in targets.reachable_rooms
 
 
@@ -1235,6 +1234,95 @@ async def test_room_players_do_not_block(game: ClueGame):
     targets = game.get_reachable_targets(whose_turn, state, 6)
     # Should still be able to reach hallway/rooms (door is not blocked)
     assert len(targets.reachable_positions) > 0 or len(targets.reachable_rooms) > 0
+
+
+@pytest.mark.asyncio
+async def test_reenter_room_via_different_door(game: ClueGame):
+    """A player in a multi-door room can leave one door and re-enter another."""
+    await _add_two_players(game)
+    state = await game.start()
+    whose_turn = state.whose_turn
+
+    # Place player in Ballroom (4 doors — re-entry should be possible with a decent roll)
+    st = await game._load_state()
+    st.current_room[whose_turn] = "Ballroom"
+    center = ROOM_CENTERS.get("Ballroom")
+    if center:
+        st.player_positions[whose_turn] = list(center)
+    await game._save_state(st)
+
+    state = await game._load_state()
+    # With a high roll, should be able to re-enter via a different door
+    targets = game.get_reachable_targets(whose_turn, state, 12)
+    assert "Ballroom" in targets.reachable_rooms
+
+
+@pytest.mark.asyncio
+async def test_cannot_reenter_single_door_room(game: ClueGame):
+    """A player in a single-door room cannot re-enter it."""
+    await _add_two_players(game)
+    state = await game.start()
+    whose_turn = state.whose_turn
+
+    # Kitchen has only 1 door — re-entry impossible
+    st = await game._load_state()
+    st.current_room[whose_turn] = "Kitchen"
+    center = ROOM_CENTERS.get("Kitchen")
+    if center:
+        st.player_positions[whose_turn] = list(center)
+    await game._save_state(st)
+
+    state = await game._load_state()
+    targets = game.get_reachable_targets(whose_turn, state, 12)
+    assert "Kitchen" not in targets.reachable_rooms
+
+
+@pytest.mark.asyncio
+async def test_move_to_secret_passage_room_after_roll(game: ClueGame):
+    """After rolling, the player can choose the secret passage destination as a move."""
+    await _add_two_players(game)
+    state = await game.start()
+    whose_turn = state.whose_turn
+
+    # Place player in Study (passage to Kitchen)
+    st = await game._load_state()
+    st.current_room[whose_turn] = "Study"
+    center = ROOM_CENTERS.get("Study")
+    if center:
+        st.player_positions[whose_turn] = list(center)
+    await game._save_state(st)
+
+    # Roll dice
+    await game.process_action(whose_turn, {"type": "roll"})
+
+    # Move to Kitchen via secret passage
+    result = await game.process_action(whose_turn, {"type": "move", "room": "Kitchen"})
+    assert result.room == "Kitchen"
+
+
+@pytest.mark.asyncio
+async def test_reenter_same_room_move_action(game: ClueGame):
+    """A player can actually move back into a multi-door room after rolling."""
+    await _add_two_players(game)
+    state = await game.start()
+    whose_turn = state.whose_turn
+
+    # Place in Ballroom (4 doors)
+    st = await game._load_state()
+    st.current_room[whose_turn] = "Ballroom"
+    center = ROOM_CENTERS.get("Ballroom")
+    if center:
+        st.player_positions[whose_turn] = list(center)
+    await game._save_state(st)
+
+    # Roll dice — mock a high roll to ensure re-entry is possible
+    st = await game._load_state()
+    st.dice_rolled = True
+    st.last_roll = [6, 6]
+    await game._save_state(st)
+
+    result = await game.process_action(whose_turn, {"type": "move", "room": "Ballroom"})
+    assert result.room == "Ballroom"
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
- Secret passage destinations now appear in reachable_rooms after rolling,
  so players can choose them as move targets alongside walkable rooms
- Players can leave and re-enter the same room if it has multiple doors
  and the dice roll is sufficient to walk between them
- Added can_reenter_via_different_door() BFS helper in board.py

https://claude.ai/code/session_011ZTKcFnukbX51FamvV4FT6