### PR TITLE
Reorganize clue image variants and add image preview browser

### DIFF
--- a/frontend/src/App.vue
+++ b/frontend/src/App.vue
@@ -104,7 +104,7 @@ function parseGameIdFromUrl() {
   // Check admin route
   if (window.location.pathname === '/admin') return { admin: true }
   // Check images route
-  if (window.location.pathname === '/images') return { images: true }
+  if (window.location.pathname === '/image-browser') return { images: true }
   // Check debug route
   const debugMatch = window.location.pathname.match(/^\/clue\/([A-Za-z0-9]+)\/debug/)
   if (debugMatch) return { debug: true, debugGameId: debugMatch[1].toUpperCase() }


### PR DESCRIPTION
$(cat <<'EOF'
## Summary

- **Restructure image directories**: variants are now top-level under `frontend/public/images/clue/`. Original assets live in `clue/default/`; alternate sets live in `clue/vintage/` and `clue/flirtatious/` (previously nested under `clue/alternates/`).
- **Update all URL references**: `CARD_IMAGES` and `THEME_CARD_IMAGES` in `clue.ts` updated to new paths; hardcoded paths in `BoardMap.vue` (`magnifying-glass.jpg`, `board.png`) updated to `default/`.
- **Export `IMAGE_VARIANTS`**: new typed array in `clue.ts` describes every variant with its full set of suspect/weapon/room/board image URLs — single source of truth for the preview browser and any future consumers.
- **Add `ImageVariantBrowser.vue`**: gallery component accessible at `/image-browser` that shows all images for a selected variant, grouped by Board / Suspects / Weapons / Rooms, with a tab per variant.

## New directory structure

```
images/clue/
├── default/       ← primary variant (suspects, weapons, rooms, board, magnifying-glass)
├── vintage/       ← vintage room illustrations
└── flirtatious/   ← alternate suspect portraits
```

## Test plan

- [ ] Visit `/image-browser` — verify three variant tabs render and all images load
- [ ] Play a Clue game — verify board, room cards, suspect thumbnails, and weapon thumbnails all display correctly
- [ ] Switch theme to Vintage in-game — verify room card overrides still work
- [ ] Switch theme to Flirtatious — verify suspect portrait overrides still work

https://claude.ai/code/session_0169w1wQMoTCDvL9hdwCvxzz
EOF
)

---
_Generated by [Claude Code](https://claude.ai/code/session_0169w1wQMoTCDvL9hdwCvxzz)_