### PR TITLE
Add missing backend SPA route for /image-browser

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -2512,6 +2512,15 @@ async def spa_admin_route():
     return {"detail": "Not found"}
 
 
+@app.get("/image-browser")
+async def spa_image_browser_route():
+    """Serve index.html for /image-browser so the Vue SPA can handle routing."""
+    index = _static_dir / "index.html"
+    if index.exists():
+        return FileResponse(str(index))
+    return {"detail": "Not found"}
+
+
 # ---------------------------------------------------------------------------
 # Static files (Vue build output)
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
The prior fix renamed the frontend path from /images to /image-browser
but omitted the corresponding FastAPI catch-all route that serves
index.html, causing direct navigation to /image-browser to 404.

https://claude.ai/code/session_01K8gPYwvGSdwWemozGGcTvm