### PR TITLE
ci: add docker ecosystem to dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -36,3 +36,13 @@ updates:
       github-actions:
         patterns:
           - "actions/*"
+
+  - package-ecosystem: "docker"
+    directory: "/backend"
+    schedule:
+      interval: "weekly"
+
+  - package-ecosystem: "docker"
+    directory: "/frontend"
+    schedule:
+      interval: "weekly"


### PR DESCRIPTION
Extend dependabot coverage to include the backend and frontend Dockerfiles
so base image updates get the same weekly PR treatment as npm/pip/actions.